### PR TITLE
fix(readme): retryconfig option do not receive a retryconfig struct parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,11 +233,12 @@ The client automatically retries on network errors and 5xx responses:
 ```go
 client := client.NewMgcClient(
     apiToken,
-    client.WithRetryConfig(client.RetryConfig{
-        MaxAttempts: 3,
-        InitialInterval: 1 * time.Second,
-        MaxInterval: 30 * time.Second,
-    }),
+    client.WithRetryConfig(
+        3, // maxAttempts
+        1 * time.Second, // initialInterval
+        30 * time.Second, // maxInterval
+        1.5, // backoffFactor
+    ),
 )
 ```
 


### PR DESCRIPTION
## What does this PR do?
Fixes README removing incorrect call to `client.WithRetryConfig()` with `client.RetryConfig{}` as a parameter, since the struct is not a valid parameter

## How Has This Been Tested?
<!-- Please describe the tests you ran to verify your changes and how you tested them. Include any relevant details and evidence. -->
- **Unit Tests**: N/A

- **Integration Tests**: N/A

- **Manual Testing**: N/A

## Checklist
- [x] I have run Pre commit `pre-commit run --all-files`
- [x] My code follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots/Videos
N/A