### PR TITLE
docs: fix parameter to set region

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ When using global services, any region configuration set on the core client will
 
 ```go
 // Even if core client has a region set
-core := client.NewMgcClient(apiToken, client.WithRegion(client.BrMgl1))
+core := client.NewMgcClient(apiToken, client.WithBaseURL(client.BrSe1))
 
 // Global services will ignore the region and use global endpoint
 sshClient := sshkeys.New(core) // Uses api.magalu.cloud
@@ -130,6 +130,7 @@ c := client.NewMgcClient(
         30 * time.Second, // maxInterval
         1.5, // backoffFactor
     ),
+    client.WithBaseURL(client.BrSe1),
 )
 ```
 
@@ -139,7 +140,7 @@ Available options:
 - `WithLogger`: Configures a custom logger
 - `WithRetryConfig`: Customizes the retry behavior
 - `WithHTTPClient`: Uses a custom HTTP client
-- `WithBaseURL`: Changes the API endpoint (useful for testing)
+- `WithBaseURL`: Changes the API endpoint (useful for testing or setting a specific region to interact)
 
 ### Listing Instances
 


### PR DESCRIPTION
## What does this PR do?
Update docs to inform the correct function to set region on MGC Client.

## How Has This Been Tested?
Run block-storage product example using the following code line in client init:
c := client.NewMgcClient(apiToken, client.WithBaseURL(client.BrSe1))

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
