### PR TITLE
fix: remove .Items when creating an instace with a custom security group

### DIFF
--- a/compute/instances.go
+++ b/compute/instances.go
@@ -83,8 +83,8 @@ type (
 	}
 
 	CreateParametersNetworkInterface struct {
-		Interface      IDOrName                                              `json:"interface"`
-		SecurityGroups *[]CreateParametersNetworkInterfaceSecurityGroupsItem `json:"security_groups,omitempty"`
+		Interface      IDOrName                                             `json:"interface"`
+		SecurityGroups []CreateParametersNetworkInterfaceSecurityGroupsItem `json:"security_groups,omitempty"`
 	}
 
 	CreateParametersNetworkInterfaceSecurityGroupsItem struct {
@@ -92,8 +92,8 @@ type (
 	}
 
 	CreateParametersNetworkVpc struct {
-		Vpc            IDOrName                                              `json:"vpc"`
-		SecurityGroups *[]CreateParametersNetworkInterfaceSecurityGroupsItem `json:"security_groups,omitempty"`
+		Vpc            IDOrName                                             `json:"vpc"`
+		SecurityGroups []CreateParametersNetworkInterfaceSecurityGroupsItem `json:"security_groups,omitempty"`
 	}
 
 	IDOrName struct {


### PR DESCRIPTION
## What does this PR do?
It corrects the `InstaceService.Create()` method by removing the `.Items` field when specifying a custom Security Group.

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
