### PR TITLE
fix: update timestamp format to include fractional seconds

### DIFF
--- a/internal/utils/types.go
+++ b/internal/utils/types.go
@@ -7,7 +7,7 @@ import (
 
 type LocalDateTimeWithoutZone time.Time
 
-const LocalDateTimeWithoutZoneLayout = "2006-01-02T15:04:05"
+const LocalDateTimeWithoutZoneLayout = "2006-01-02T15:04:05.000000"
 
 func (ct *LocalDateTimeWithoutZone) UnmarshalJSON(data []byte) error {
 	s := strings.Trim(string(data), `"`)

--- a/internal/utils/types_test.go
+++ b/internal/utils/types_test.go
@@ -14,18 +14,18 @@ func TestLocalDateTimeWithoutZone_UnmarshalJSON(t *testing.T) {
 	}{
 		{
 			name:    "valid time",
-			data:    []byte(`"2023-01-02T12:34:56"`),
+			data:    []byte(`"2023-01-02T12:34:56.000000"`),
 			want:    time.Date(2023, time.January, 2, 12, 34, 56, 0, time.UTC),
 			wantErr: false,
 		},
 		{
 			name:    "invalid format with space",
-			data:    []byte(`"2023-01-02 12:34:56"`),
+			data:    []byte(`"2023-01-02 12:34:56.000000"`),
 			wantErr: true,
 		},
 		{
 			name:    "invalid month",
-			data:    []byte(`"2023-13-02T12:34:56"`),
+			data:    []byte(`"2023-13-02T12:34:56.000000"`),
 			wantErr: true,
 		},
 		{
@@ -71,19 +71,19 @@ func TestLocalDateTimeWithoutZone_MarshalJSON(t *testing.T) {
 		{
 			name:    "valid UTC time",
 			ct:      LocalDateTimeWithoutZone(time.Date(2023, time.January, 2, 12, 34, 56, 0, time.UTC)),
-			want:    []byte(`"2023-01-02T12:34:56"`),
+			want:    []byte(`"2023-01-02T12:34:56.000000"`),
 			wantErr: false,
 		},
 		{
 			name:    "valid non-UTC time",
 			ct:      LocalDateTimeWithoutZone(time.Date(2023, time.January, 2, 12, 34, 56, 0, loc)),
-			want:    []byte(`"2023-01-02T12:34:56"`),
+			want:    []byte(`"2023-01-02T12:34:56.000000"`),
 			wantErr: false,
 		},
 		{
 			name:    "zero time",
 			ct:      LocalDateTimeWithoutZone(time.Time{}),
-			want:    []byte(`"0001-01-01T00:00:00"`),
+			want:    []byte(`"0001-01-01T00:00:00.000000"`),
 			wantErr: false,
 		},
 	}
@@ -111,12 +111,12 @@ func TestLocalDateTimeWithoutZone_String(t *testing.T) {
 		{
 			name: "valid time",
 			ct:   LocalDateTimeWithoutZone(time.Date(2023, time.January, 2, 12, 34, 56, 0, time.UTC)),
-			want: "2023-01-02T12:34:56",
+			want: "2023-01-02T12:34:56.000000",
 		},
 		{
 			name: "zero time",
 			ct:   LocalDateTimeWithoutZone(time.Time{}),
-			want: "0001-01-01T00:00:00",
+			want: "0001-01-01T00:00:00.000000",
 		},
 	}
 

--- a/network/public_ips_test.go
+++ b/network/public_ips_test.go
@@ -96,8 +96,8 @@ func TestPublicIPService_Get(t *testing.T) {
 				"public_ip": "203.0.113.5",
 				"vpc_id": "vpc1",
 				"status": "ACTIVE",
-				"created_at": "2024-01-01T00:00:00",
-				"updated": "2024-01-02T00:00:00"
+				"created_at": "2024-01-01T00:00:00.000000",
+				"updated": "2024-01-02T00:00:00.000000"
 			}`,
 			statusCode: http.StatusOK,
 			want: &PublicIPResponse{

--- a/network/rules_test.go
+++ b/network/rules_test.go
@@ -102,7 +102,7 @@ func TestRuleService_Get(t *testing.T) {
 				"protocol": "tcp",
 				"port_range_min": 80,
 				"port_range_max": 80,
-				"created_at": "2024-01-01T00:00:00",
+				"created_at": "2024-01-01T00:00:00.000000",
 				"status": "ACTIVE"
 			}`,
 			statusCode: http.StatusOK,

--- a/network/security_groups_test.go
+++ b/network/security_groups_test.go
@@ -99,8 +99,8 @@ func TestSecurityGroupService_Get(t *testing.T) {
 				"rules": [
 					{"id": "rule1", "direction": "ingress"}
 				],
-				"created_at": "2024-01-01T00:00:00",
-				"updated": "2024-01-01T00:00:00"
+				"created_at": "2024-01-01T00:00:00.000000",
+				"updated": "2024-01-01T00:00:00.000000"
 			}`,
 			statusCode: http.StatusOK,
 			want: &SecurityGroupDetailResponse{

--- a/network/subnetpools_test.go
+++ b/network/subnetpools_test.go
@@ -119,7 +119,7 @@ func TestSubnetPoolService_Get(t *testing.T) {
 				"name": "test-pool",
 				"cidr": "10.0.0.0/16",
 				"ip_version": 4,
-				"created_at": "2024-01-01T00:00:00"
+				"created_at": "2024-01-01T00:00:00.000000"
 			}`,
 			statusCode: http.StatusOK,
 			want: &SubnetPoolDetailsResponse{

--- a/network/subnets_test.go
+++ b/network/subnets_test.go
@@ -37,8 +37,8 @@ func TestSubnetService_Get(t *testing.T) {
 				"gateway_ip": "10.0.0.1",
 				"dns_nameservers": ["8.8.8.8"],
 				"dhcp_pools": [{"start": "10.0.0.100", "end": "10.0.0.200"}],
-				"created_at": "2024-01-01T00:00:00",
-				"updated": "2024-01-01T00:00:00"
+				"created_at": "2024-01-01T00:00:00.000000",
+				"updated": "2024-01-01T00:00:00.000000"
 			}`,
 			statusCode: http.StatusOK,
 			want: &SubnetResponseDetail{

--- a/network/vpcs_test.go
+++ b/network/vpcs_test.go
@@ -359,7 +359,7 @@ func TestVPCService_ListPublicIPs(t *testing.T) {
 			vpcID: "vpc1",
 			response: `{
 				"public_ips": [
-					{"id": "ip1", "public_ip": "203.0.113.1", "created_at": "2024-01-01T00:00:00"},
+					{"id": "ip1", "public_ip": "203.0.113.1", "created_at": "2024-01-01T00:00:00.000000"},
 					{"id": "ip2", "public_ip": "203.0.113.2"}
 				]
 			}`,
@@ -627,7 +627,7 @@ func TestVPCService_List(t *testing.T) {
 						"name": "prod-vpc",
 						"security_groups": ["sg1", "sg2"],
 						"subnets": ["subnet1"],
-						"created_at": "2024-01-01T00:00:00"
+						"created_at": "2024-01-01T00:00:00.000000"
 					}
 				]
 			}`,
@@ -708,7 +708,7 @@ func TestVPCService_Get(t *testing.T) {
 				"name": "prod-vpc",
 				"security_groups": ["sg1", "sg2"],
 				"subnets": ["subnet1"],
-				"created_at": "2024-01-01T00:00:00",
+				"created_at": "2024-01-01T00:00:00.000000",
 				"is_default": true
 			}`,
 			statusCode: http.StatusOK,


### PR DESCRIPTION
## What does this PR do?
<!-- Provide a clear and concise description of the changes -->
- fix: update timestamp format to include fractional seconds
- This was a issue with network api returning time with ms 

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
