### PR TITLE
fix: change vpc delete version back to v0

### DIFF
--- a/network/vpcs.go
+++ b/network/vpcs.go
@@ -275,7 +275,7 @@ func (s *vpcService) Delete(ctx context.Context, id string) error {
 		s.client.newRequest,
 		s.client.GetConfig(),
 		http.MethodDelete,
-		fmt.Sprintf("/v1/vpcs/%s", id),
+		fmt.Sprintf("/v0/vpcs/%s", id),
 		nil,
 		nil,
 	)

--- a/network/vpcs_test.go
+++ b/network/vpcs_test.go
@@ -108,7 +108,7 @@ func TestVPCService_Delete(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				assertEqual(t, fmt.Sprintf("/network/v1/vpcs/%s", tt.id), r.URL.Path)
+				assertEqual(t, fmt.Sprintf("/network/v0/vpcs/%s", tt.id), r.URL.Path)
 				assertEqual(t, http.MethodDelete, r.Method)
 				w.WriteHeader(tt.statusCode)
 				if tt.response != "" {


### PR DESCRIPTION
## What does this PR do?
<!-- Provide a clear and concise description of the changes -->
- Adjust the network vpc delete endpoint to the original v0 version

## How Has This Been Tested?
<!-- Please describe the tests you ran to verify your changes and how you tested them. Include any relevant details and evidence. -->

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
