### PR TITLE
fix: remove expand parameter from get cluster

### DIFF
--- a/cmd/examples/kubernetes/main.go
+++ b/cmd/examples/kubernetes/main.go
@@ -120,7 +120,7 @@ func deleteAllClusters(k8sClient *kubernetes.KubernetesClient) {
 
 func WaitClusterRunning(k8sClient *kubernetes.KubernetesClient, clusterID string) {
 	for {
-		cluster, err := k8sClient.Clusters().Get(context.Background(), clusterID, nil)
+		cluster, err := k8sClient.Clusters().Get(context.Background(), clusterID)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -209,7 +209,7 @@ func ExampleListClusters(k8sClient *kubernetes.KubernetesClient) {
 func ExampleGetCluster(k8sClient *kubernetes.KubernetesClient, clusterID string) {
 	ctx := context.Background()
 
-	cluster, err := k8sClient.Clusters().Get(ctx, clusterID, []string{"node_pools"})
+	cluster, err := k8sClient.Clusters().Get(ctx, clusterID)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -424,7 +424,7 @@ func waitForClusterStatus(ctx context.Context, client *kubernetes.KubernetesClie
 		case <-ctx.Done():
 			return fmt.Errorf("timeout esperando status do cluster")
 		case <-ticker.C:
-			cluster, err := client.Clusters().Get(ctx, clusterID, nil)
+			cluster, err := client.Clusters().Get(ctx, clusterID)
 			if err != nil {
 				return err
 			}

--- a/cmd/examples/kubernetes_small/main.go
+++ b/cmd/examples/kubernetes_small/main.go
@@ -55,7 +55,7 @@ func GetNodes(k8sClient *kubernetes.KubernetesClient, clusterID string, nodePool
 
 func WaitClusterRunning(k8sClient *kubernetes.KubernetesClient, clusterID string) {
 	for {
-		cluster, err := k8sClient.Clusters().Get(context.Background(), clusterID, nil)
+		cluster, err := k8sClient.Clusters().Get(context.Background(), clusterID)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -144,7 +144,7 @@ func ExampleListClusters(k8sClient *kubernetes.KubernetesClient) {
 func ExampleGetCluster(k8sClient *kubernetes.KubernetesClient, clusterID string) {
 	ctx := context.Background()
 
-	cluster, err := k8sClient.Clusters().Get(ctx, clusterID, []string{"node_pools"})
+	cluster, err := k8sClient.Clusters().Get(ctx, clusterID)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -359,7 +359,7 @@ func waitForClusterStatus(ctx context.Context, client *kubernetes.KubernetesClie
 		case <-ctx.Done():
 			return fmt.Errorf("timeout esperando status do cluster")
 		case <-ticker.C:
-			cluster, err := client.Clusters().Get(ctx, clusterID, nil)
+			cluster, err := client.Clusters().Get(ctx, clusterID)
 			if err != nil {
 				return err
 			}

--- a/kubernetes/cluster.go
+++ b/kubernetes/cluster.go
@@ -22,7 +22,7 @@ type (
 	ClusterService interface {
 		List(ctx context.Context, opts ListOptions) ([]ClusterList, error)
 		Create(ctx context.Context, req ClusterRequest) (*CreateClusterResponse, error)
-		Get(ctx context.Context, clusterID string, expand []string) (*Cluster, error)
+		Get(ctx context.Context, clusterID string) (*Cluster, error)
 		Delete(ctx context.Context, clusterID string) error
 		Update(ctx context.Context, clusterID string, req AllowedCIDRsUpdateRequest) (*Cluster, error)
 		GetKubeConfig(ctx context.Context, clusterID string) (*KubeConfig, error)
@@ -195,18 +195,11 @@ func (s *clusterService) Create(ctx context.Context, req ClusterRequest) (*Creat
 	return response, nil
 }
 
-func (s *clusterService) Get(ctx context.Context, clusterID string, expand []string) (*Cluster, error) {
+func (s *clusterService) Get(ctx context.Context, clusterID string) (*Cluster, error) {
 	if clusterID == "" {
 		return nil, &client.ValidationError{Field: "clusterID", Message: utils.CannotBeEmpty}
 	}
-
 	getClusterURL := fmt.Sprintf(clusterUrlWithID, clusterID)
-
-	if len(expand) > 0 {
-		q := url.Values{}
-		q.Add("expand", strings.Join(expand, ","))
-		getClusterURL += "?" + q.Encode()
-	}
 
 	cluster, err := mgc_http.ExecuteSimpleRequestWithRespBody[Cluster](ctx, s.client.newRequest, s.client.GetConfig(), http.MethodGet, getClusterURL, nil, nil)
 	if err != nil {

--- a/kubernetes/cluster_test.go
+++ b/kubernetes/cluster_test.go
@@ -251,7 +251,7 @@ func TestClusterService_Get(t *testing.T) {
 			defer server.Close()
 
 			client := testClient(server.URL)
-			result, err := client.Clusters().Get(context.Background(), tt.clusterID, []string{"network"})
+			result, err := client.Clusters().Get(context.Background(), tt.clusterID)
 
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Get() error = %v, wantErr %v", err, tt.wantErr)
@@ -421,7 +421,7 @@ func TestClusterService_ValidationErrors(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			client := testClient("http://dummy")
-			_, err := client.Clusters().Get(context.Background(), tt.clusterID, []string{})
+			_, err := client.Clusters().Get(context.Background(), tt.clusterID)
 
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Validation error = %v, wantErr %v", err, tt.wantErr)
@@ -442,7 +442,7 @@ func TestClusterService_EdgeCases(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
 		defer cancel()
 
-		_, err := client.Clusters().Get(ctx, "cluster-123", []string{})
+		_, err := client.Clusters().Get(ctx, "cluster-123")
 		if err == nil {
 			t.Error("Esperado erro de timeout")
 		}
@@ -456,7 +456,7 @@ func TestClusterService_EdgeCases(t *testing.T) {
 		defer server.Close()
 
 		client := testClient(server.URL)
-		_, err := client.Clusters().Get(context.Background(), "cluster-123", []string{})
+		_, err := client.Clusters().Get(context.Background(), "cluster-123")
 		if err == nil {
 			t.Error("Esperado erro de parsing")
 		}


### PR DESCRIPTION
## What does this PR do?
<!-- Provide a clear and concise description of the changes -->
- Remove the parameter extend from create cluster, the parameter does not exist in the api

## How Has This Been Tested?
<!-- Please describe the tests you ran to verify your changes and how you tested them. Include any relevant details and evidence. -->

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
