### PR TITLE
fix(ports): typo on request struct

### DIFF
--- a/cmd/examples/network/main.go
+++ b/cmd/examples/network/main.go
@@ -882,7 +882,7 @@ func updatePort(networkClient *network.NetworkClient, portID string) {
 	defer cancel()
 
 	portUpdateRequest := &network.PortUpdateRequest{
-		IsSpoofingGuard: helpers.BoolPtr(false),
+		IPSpoofingGuard: helpers.BoolPtr(false),
 	}
 
 	if err := networkClient.Ports().Update(ctx, portID, *portUpdateRequest); err != nil {

--- a/network/ports.go
+++ b/network/ports.go
@@ -41,7 +41,7 @@ type (
 	// PortUpdateRequest represents the fields available for update in a port resource
 	PortUpdateRequest struct {
 		// Allows spoofed packets to enter a port
-		IsSpoofingGuard *bool `json:"is_spoofing_guard,omitempty"`
+		IPSpoofingGuard *bool `json:"ip_spoofing_guard,omitempty"`
 	}
 )
 

--- a/network/ports_test.go
+++ b/network/ports_test.go
@@ -399,13 +399,13 @@ func TestPortService_Update(t *testing.T) {
 		{
 			name:       "successful update",
 			portID:     "port1",
-			request:    PortUpdateRequest{IsSpoofingGuard: helpers.BoolPtr(false)},
+			request:    PortUpdateRequest{IPSpoofingGuard: helpers.BoolPtr(false)},
 			statusCode: http.StatusNoContent,
 		},
 		{
 			name:       "update failed - port not found",
 			portID:     "port2",
-			request:    PortUpdateRequest{IsSpoofingGuard: helpers.BoolPtr(true)},
+			request:    PortUpdateRequest{IPSpoofingGuard: helpers.BoolPtr(true)},
 			statusCode: http.StatusNotFound,
 			wantErr:    true,
 		},
@@ -425,7 +425,7 @@ func TestPortService_Update(t *testing.T) {
 					err := json.NewDecoder(r.Body).Decode(&req)
 					assertNoError(t, err)
 
-					assertEqual(t, *tt.request.IsSpoofingGuard, *req.IsSpoofingGuard)
+					assertEqual(t, *tt.request.IPSpoofingGuard, *req.IPSpoofingGuard)
 
 				}
 			}))


### PR DESCRIPTION
## What does this PR do?
<!-- Provide a clear and concise description of the changes -->
Fixes a typo introduced by PR [#98](https://github.com/MagaluCloud/mgc-sdk-go/pull/98) on the `Update` operation for ports.

## How Has This Been Tested?
<!-- Please describe the tests you ran to verify your changes and how you tested them. Include any relevant details and evidence. -->

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
