### PR TITLE
chore: add godoc to dbaas cluster AddressPurpose

### DIFF
--- a/dbaas/clusters.go
+++ b/dbaas/clusters.go
@@ -43,6 +43,7 @@ type (
 		ParameterGroupID *string
 	}
 
+	// AddressPurpose represents the network address purpose on a cluster
 	AddressPurpose string
 
 	// ClustersResponse represents the response when listing clusters


### PR DESCRIPTION
## What does this PR do?
Adds go doc string to new DBaaS cluster type

## How Has This Been Tested?
No test was run, it's just docs

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
