### PR TITLE
feat: dbaas replicas resize volume

### DIFF
--- a/dbaas/replicas.go
+++ b/dbaas/replicas.go
@@ -68,7 +68,8 @@ type (
 
 	// ReplicaResizeRequest represents the request payload for resizing a replica
 	ReplicaResizeRequest struct {
-		InstanceTypeID string `json:"instance_type_id,omitempty"`
+		InstanceTypeID *string                      `json:"instance_type_id,omitempty"`
+		Volume         *InstanceVolumeResizeRequest `json:"volume,omitempty"`
 	}
 
 	// ReplicaResponse represents the response when creating a replica


### PR DESCRIPTION
## What does this PR do?
Adds the volume.size parameter to DBaaS Replica Resize request.

## How Has This Been Tested?
Along with TF Client Provider managing replica resources and resizing it accordingly.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
