### PR TITLE
Feat/k8s subnet custom and upgrade version

### DIFF
--- a/kubernetes/cluster.go
+++ b/kubernetes/cluster.go
@@ -122,11 +122,13 @@ type (
 	// PatchClusterRequest represents the request payload for patching a cluster
 	PatchClusterRequest struct {
 		AllowedCIDRs *[]string `json:"allowed_cidrs,omitempty"`
+		Version      *string   `json:"version,omitempty"`
 	}
 
 	// PatchClusterResponse represents the response when patching a cluster
 	PatchClusterResponse struct {
 		AllowedCIDRs *[]string `json:"allowed_cidrs,omitempty"`
+		Version      *string   `json:"version,omitempty"`
 	}
 
 	// MachineTypesSource represents the source of machine types

--- a/kubernetes/cluster.go
+++ b/kubernetes/cluster.go
@@ -28,6 +28,8 @@ type (
 		Update(ctx context.Context, clusterID string, req PatchClusterRequest) (*PatchClusterResponse, error)
 		GetKubeConfig(ctx context.Context, clusterID string) (*KubeConfig, error)
 	}
+
+	//VPC related network settings
 	Network struct {
 		VPCID   string   `json:"vpc_id,omitempty"`
 		Subnets []Subnet `json:"subnets,omitempty"`

--- a/kubernetes/cluster.go
+++ b/kubernetes/cluster.go
@@ -28,13 +28,15 @@ type (
 		Update(ctx context.Context, clusterID string, req PatchClusterRequest) (*PatchClusterResponse, error)
 		GetKubeConfig(ctx context.Context, clusterID string) (*KubeConfig, error)
 	}
-
-	// Network represents network configuration for a cluster
 	Network struct {
-		UUID     string `json:"uuid"`
-		CIDR     string `json:"cidr"`
-		Name     string `json:"name"`
-		SubnetID string `json:"subnet_id"`
+		VPCID   string   `json:"vpc_id,omitempty"`
+		Subnets []Subnet `json:"subnets,omitempty"`
+	}
+
+	Subnet struct {
+		ID               string `json:"id"`
+		CIDR             string `json:"cidr"`
+		AvailabilityZone string `json:"availability_zone"`
 	}
 
 	// Addons represents cluster addons configuration
@@ -109,26 +111,29 @@ type (
 
 	// ClusterRequest represents the request payload for creating a cluster
 	ClusterRequest struct {
-		Name               string                   `json:"name"`
-		Version            *string                  `json:"version,omitempty"`
-		Description        *string                  `json:"description,omitempty"`
-		EnabledServerGroup *bool                    `json:"enabled_server_group,omitempty"`
-		NodePools          *[]CreateNodePoolRequest `json:"node_pools,omitempty"`
-		AllowedCIDRs       *[]string                `json:"allowed_cidrs,omitempty"`
-		ServicesIpV4CIDR   *string                  `json:"services_ipv4_cidr,omitempty"`
-		ClusterIPv4CIDR    *string                  `json:"cluster_ipv4_cidr,omitempty"`
+		Name               string                    `json:"name"`
+		Version            *string                   `json:"version,omitempty"`
+		Description        *string                   `json:"description,omitempty"`
+		EnabledServerGroup *bool                     `json:"enabled_server_group,omitempty"`
+		NodePools          *[]CreateNodePoolRequest  `json:"node_pools,omitempty"`
+		AllowedCIDRs       *[]string                 `json:"allowed_cidrs,omitempty"`
+		ServicesIpV4CIDR   *string                   `json:"services_ipv4_cidr,omitempty"`
+		ClusterIPv4CIDR    *string                   `json:"cluster_ipv4_cidr,omitempty"`
+		Network            *KubernetesNetworkRequest `json:"network,omitempty"`
 	}
 
 	// PatchClusterRequest represents the request payload for patching a cluster
 	PatchClusterRequest struct {
 		AllowedCIDRs *[]string `json:"allowed_cidrs,omitempty"`
 		Version      *string   `json:"version,omitempty"`
+		Description  *string   `json:"description,omitempty"`
 	}
 
 	// PatchClusterResponse represents the response when patching a cluster
 	PatchClusterResponse struct {
 		AllowedCIDRs *[]string `json:"allowed_cidrs,omitempty"`
 		Version      *string   `json:"version,omitempty"`
+		Description  *string   `json:"description,omitempty"`
 	}
 
 	// MachineTypesSource represents the source of machine types

--- a/kubernetes/cluster_test.go
+++ b/kubernetes/cluster_test.go
@@ -337,6 +337,55 @@ func TestClusterService_Update(t *testing.T) {
 	}
 }
 
+func TestClusterService_Upgrade(t *testing.T) {
+	tests := []struct {
+		name        string
+		clusterID   string
+		request     PatchClusterRequest
+		response    string
+		statusCode  int
+		wantVersion string
+		wantErr     bool
+	}{
+		{
+			name:        "successful control plane upgrade",
+			clusterID:   "a2d62e93-73e0-4e0d-a632-8c35bea9e9e0",
+			request:     PatchClusterRequest{Version: strPtr("v1.31.0")},
+			response:    `{"version": "v1.31.0"}`,
+			statusCode:  http.StatusOK,
+			wantVersion: "v1.31.0",
+			wantErr:     false,
+		},
+		{
+			name:    "empty cluster ID",
+			request: PatchClusterRequest{Version: strPtr("v1.31.0")},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tt.statusCode)
+				w.Write([]byte(tt.response))
+			}))
+			defer server.Close()
+
+			client := testClient(server.URL)
+			result, err := client.Clusters().Update(context.Background(), tt.clusterID, tt.request)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Upgrade() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if !tt.wantErr && (result.Version == nil || *result.Version != tt.wantVersion) {
+				t.Errorf("Upgrade() version = %v, want %s", result.Version, tt.wantVersion)
+			}
+		})
+	}
+}
+
 func TestClusterService_GetKubeConfig(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/kubernetes/cluster_test.go
+++ b/kubernetes/cluster_test.go
@@ -2,6 +2,8 @@ package kubernetes
 
 import (
 	"context"
+	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -149,6 +151,47 @@ func TestClusterService_Create(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestClusterService_Create_WithCustomerChosenSubnets(t *testing.T) {
+	t.Parallel()
+
+	t.Run("customer informs which subnets host the control plane", func(t *testing.T) {
+		t.Parallel()
+		chosenSubnets := []string{
+			"11111111-1111-1111-1111-111111111111",
+			"22222222-2222-2222-2222-222222222222",
+		}
+
+		var sentPayload map[string]any
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			body, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(body, &sentPayload)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			w.Write([]byte(`{"id":"33333333-3333-3333-3333-33333333333","name":"cluster-new","status":{"state":"Pending","message":""}}`))
+		}))
+		defer server.Close()
+
+		_, err := testClient(server.URL).Clusters().Create(context.Background(), ClusterRequest{
+			Name: "cluster-new",
+			Network: &KubernetesNetworkRequest{
+				SubnetIDs: chosenSubnets,
+			},
+		})
+		if err != nil {
+			t.Fatalf("Create() erro inesperado: %v", err)
+		}
+
+		network := sentPayload["network"].(map[string]any)
+		rawIDs := network["subnet_ids"].([]any)
+
+		for i, id := range chosenSubnets {
+			if rawIDs[i] != id {
+				t.Errorf("subnet[%d] enviada = %v, esperava %s", i, rawIDs[i], id)
+			}
+		}
+	})
 }
 
 func TestClusterService_Delete(t *testing.T) {

--- a/kubernetes/commons.go
+++ b/kubernetes/commons.go
@@ -71,6 +71,7 @@ type (
 		Flavor            string            `json:"flavor"`
 		MaxPodsPerNode    *int              `json:"max_pods_per_node,omitempty"`
 		AvailabilityZones *[]string         `json:"availability_zones,omitempty"`
+		Version           *string           `json:"version,omitempty"`
 	}
 
 	// CreateNodePoolRequest represents the request payload for creating a node pool

--- a/kubernetes/commons.go
+++ b/kubernetes/commons.go
@@ -72,17 +72,23 @@ type (
 		MaxPodsPerNode    *int              `json:"max_pods_per_node,omitempty"`
 		AvailabilityZones *[]string         `json:"availability_zones,omitempty"`
 		Version           *string           `json:"version,omitempty"`
+		Network           *Network          `json:"network,omitempty"`
 	}
 
 	// CreateNodePoolRequest represents the request payload for creating a node pool
 	CreateNodePoolRequest struct {
-		Name              string     `json:"name"`
-		Flavor            string     `json:"flavor"`
-		Replicas          int        `json:"replicas"`
-		Tags              *[]string  `json:"tags,omitempty"`
-		Taints            *[]Taint   `json:"taints,omitempty"`
-		AutoScale         *AutoScale `json:"auto_scale,omitempty"`
-		MaxPodsPerNode    *int       `json:"max_pods_per_node,omitempty"`
-		AvailabilityZones *[]string  `json:"availability_zones,omitempty"`
+		Name              string                    `json:"name"`
+		Flavor            string                    `json:"flavor"`
+		Replicas          int                       `json:"replicas"`
+		Tags              *[]string                 `json:"tags,omitempty"`
+		Taints            *[]Taint                  `json:"taints,omitempty"`
+		AutoScale         *AutoScale                `json:"auto_scale,omitempty"`
+		MaxPodsPerNode    *int                      `json:"max_pods_per_node,omitempty"`
+		AvailabilityZones *[]string                 `json:"availability_zones,omitempty"`
+		Network           *KubernetesNetworkRequest `json:"network,omitempty"`
+	}
+
+	KubernetesNetworkRequest struct {
+		SubnetIDs []string `json:"subnet_ids"`
 	}
 )

--- a/kubernetes/commons.go
+++ b/kubernetes/commons.go
@@ -89,6 +89,6 @@ type (
 	}
 
 	KubernetesNetworkRequest struct {
-		SubnetIDs []string `json:"subnet_ids"`
+		SubnetIDs []string `json:"subnet_ids,omitempty"`
 	}
 )

--- a/kubernetes/nodepool.go
+++ b/kubernetes/nodepool.go
@@ -90,6 +90,7 @@ type (
 	PatchNodePoolRequest struct {
 		Replicas  *int       `json:"replicas,omitempty"`
 		AutoScale *AutoScale `json:"auto_scale,omitempty"`
+		Version   *string    `json:"version,omitempty"`
 	}
 
 	// nodePoolService implements the NodePoolService interface

--- a/kubernetes/nodepool_test.go
+++ b/kubernetes/nodepool_test.go
@@ -249,6 +249,118 @@ func TestNodePoolService_Create_ValidationError(t *testing.T) {
 	}
 }
 
+func TestNodePoolService_Upgrade(t *testing.T) {
+	tests := []struct {
+		name        string
+		clusterID   string
+		nodePoolID  string
+		request     PatchNodePoolRequest
+		response    string
+		statusCode  int
+		wantVersion string
+		wantErr     bool
+	}{
+		{
+			name:        "successful node pool upgrade",
+			clusterID:   "f66d3e79-011c-49fb-9b61-228e2e0d1bd8",
+			nodePoolID:  "ca1a4386-8b75-4354-91a5-f265092c3d6f",
+			request:     PatchNodePoolRequest{Version: strPtr("v1.31.0")},
+			response:    `{"id": "ca1a4386-8b75-4354-91a5-f265092c3d6f", "version": "v1.31.0"}`,
+			statusCode:  http.StatusOK,
+			wantVersion: "v1.31.0",
+			wantErr:     false,
+		},
+		{
+			name:       "empty cluster ID",
+			nodePoolID: "ca1a4386-8b75-4354-91a5-f265092c3d6f",
+			request:    PatchNodePoolRequest{Version: strPtr("v1.31.0")},
+			wantErr:    true,
+		},
+		{
+			name:      "empty node pool ID",
+			clusterID: "f66d3e79-011c-49fb-9b61-228e2e0d1bd8",
+			request:   PatchNodePoolRequest{Version: strPtr("v1.31.0")},
+			wantErr:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tt.statusCode)
+				w.Write([]byte(tt.response))
+			}))
+			defer server.Close()
+
+			client := testClient(server.URL)
+			result, err := client.Nodepools().Update(context.Background(), tt.clusterID, tt.nodePoolID, tt.request)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Upgrade() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if !tt.wantErr && (result.Version == nil || *result.Version != tt.wantVersion) {
+				t.Errorf("Upgrade() version = %v, want %s", result.Version, tt.wantVersion)
+			}
+		})
+	}
+}
+
+func TestNodePoolService_GetWithVersion(t *testing.T) {
+	tests := []struct {
+		name        string
+		clusterID   string
+		nodePoolID  string
+		response    string
+		statusCode  int
+		wantVersion string
+		wantErr     bool
+	}{
+		{
+			name:        "node pool with version field",
+			clusterID:   "cluster-123",
+			nodePoolID:  "pool-456",
+			response:    `{"id": "pool-456", "version": "v1.30.2"}`,
+			statusCode:  http.StatusOK,
+			wantVersion: "v1.30.2",
+			wantErr:     false,
+		},
+		{
+			name:       "node pool without version field",
+			clusterID:  "cluster-123",
+			nodePoolID: "pool-456",
+			response:   `{"id": "pool-456"}`,
+			statusCode: http.StatusOK,
+			wantErr:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tt.statusCode)
+				w.Write([]byte(tt.response))
+			}))
+			defer server.Close()
+
+			client := testClient(server.URL)
+			result, err := client.Nodepools().Get(context.Background(), tt.clusterID, tt.nodePoolID)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Get() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if !tt.wantErr && tt.wantVersion != "" {
+				if result.Version == nil || *result.Version != tt.wantVersion {
+					t.Errorf("Get() version = %v, want %s", result.Version, tt.wantVersion)
+				}
+			}
+		})
+	}
+}
+
 func TestNodePoolService_Scale(t *testing.T) {
 	tests := []struct {
 		name         string

--- a/kubernetes/nodepool_test.go
+++ b/kubernetes/nodepool_test.go
@@ -2,6 +2,8 @@ package kubernetes
 
 import (
 	"context"
+	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -136,6 +138,77 @@ func TestNodePoolService_Create(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestNodePoolService_Create_WithCustomerChosenSubnets(t *testing.T) {
+	t.Parallel()
+
+	t.Run("customer informs which subnets host the worker nodes", func(t *testing.T) {
+		t.Parallel()
+		chosenSubnets := []string{
+			"33333333-3333-3333-3333-333333333333",
+			"44444444-4444-4444-4444-444444444444",
+		}
+
+		var sentPayload map[string]any
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			body, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(body, &sentPayload)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			w.Write([]byte(`{"id":"22222222-2222-2222-2222-222222222222","name":"pool-new","replicas":2,"flavor":"BV2-2-40","instance_template":{"flavor":{"name":"BV4-8-40","id":"f1","vcpu":2,"ram":4096,"size":40},"node_image":"","disk_size":40,"disk_type":""},"status":{"state":"creating"}}`))
+		}))
+		defer server.Close()
+
+		_, err := testClient(server.URL).Nodepools().Create(context.Background(), "cluster-123", CreateNodePoolRequest{
+			Name:     "pool-new",
+			Flavor:   "BV4-8-40",
+			Replicas: 2,
+			Network: &KubernetesNetworkRequest{
+				SubnetIDs: chosenSubnets,
+			},
+		})
+		if err != nil {
+			t.Fatalf("Create() erro inesperado: %v", err)
+		}
+
+		network := sentPayload["network"].(map[string]any)
+		rawIDs := network["subnet_ids"].([]any)
+		if len(rawIDs) != len(chosenSubnets) {
+			t.Fatalf("esperava %d subnets enviadas, recebi %d", len(chosenSubnets), len(rawIDs))
+		}
+		for i, id := range chosenSubnets {
+			if rawIDs[i] != id {
+				t.Errorf("subnet[%d] enviada = %v, esperava %s", i, rawIDs[i], id)
+			}
+		}
+	})
+
+	t.Run("customer omits subnets and nodepool inherits cluster subnets", func(t *testing.T) {
+		t.Parallel()
+		var sentPayload map[string]any
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			body, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(body, &sentPayload)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			w.Write([]byte(`{"id":"pool-new","name":"pool-new","replicas":2,"flavor":"BV4-8-40","instance_template":{"flavor":{"name":"BV4-8-40","id":"f1","vcpu":2,"ram":4096,"size":40},"node_image":"","disk_size":40,"disk_type":""},"status":{"state":"creating"}}`))
+		}))
+		defer server.Close()
+
+		_, err := testClient(server.URL).Nodepools().Create(context.Background(), "cluster-123", CreateNodePoolRequest{
+			Name:     "pool-new",
+			Flavor:   "BV4-8-40",
+			Replicas: 2,
+		})
+		if err != nil {
+			t.Fatalf("Create() erro inesperado: %v", err)
+		}
+
+		if _, present := sentPayload["network"]; present {
+			t.Errorf("não esperava chave network no payload quando cliente não escolhe subnets, recebi: %v", sentPayload)
+		}
+	})
 }
 
 func TestNodePoolService_Delete(t *testing.T) {


### PR DESCRIPTION
## What does this PR do?
Adiciona suporte a subnets customizadas e upgrade de versão do Kubernetes no SDK, abrangendo cluster e nodepool.

A mudança no shape da struct Network (remoção do UUID, CIDR, Name ou SubnetID direto do nodepool/cluster) feita por esse PR causa Breaking change. Entretanto, as evidências que temos é que os campos removidos não estavam sendo usados, uma vez que a API não estava retornando de forma consistente. Ainda sim, vale a pena sinalizar no release.

## How Has This Been Tested?
Usando o Terraform como cliente: 
- Criação de cluster com subnets customizadas
- Criação de nodepool herdando subnets do cluster
- PATCH update de versão no cluster e no nodepool.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
