### PR TITLE
feat: add method to create custom images

### DIFF
--- a/cmd/examples/compute/main.go
+++ b/cmd/examples/compute/main.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strings"
+	"time"
 
 	"github.com/MagaluCloud/mgc-sdk-go/client"
 	"github.com/MagaluCloud/mgc-sdk-go/compute"
@@ -12,10 +14,42 @@ import (
 )
 
 func main() {
+	// Get credentials from environment
+	apiToken := os.Getenv("MGC_API_KEY")
+	if apiToken == "" {
+		log.Fatal("MGC_API_TOKEN environment variable is not set")
+	}
+
+	// Check for optional region parameter
+	region := os.Getenv("MGC_REGION")
+	if region == "" {
+		region = "br-se1"
+	}
+
+	// Set client options
+	opts := []client.Option{client.WithAPIKey(apiToken)}
+	switch strings.ToLower(region) {
+	case "br-ne1":
+		opts = append(opts, client.WithBaseURL(client.BrNe1))
+	case "br-se1":
+		opts = append(opts, client.WithBaseURL(client.BrSe1))
+	default:
+		log.Fatalf("MGC_REGION set with invalid region %s\n", region)
+	}
+
+	// Create MagaluCloud client with selected region
+	c := client.NewMgcClient(opts...)
+
+	// Create Compute client
+	cli := compute.New(c)
+
+	ctx := context.Background()
+
 	// ExampleListMachineTypes()
 	// ExampleListImages()
 	ExampleListImagesWithJWT()
-	ExampleListImagesWithJWTAndAPIKey()
+	ExampleListImagesWithJWTAndAPIKey(ctx, apiToken)
+	ExampleCreateCustomImage(ctx, cli)
 	// id := "" // comment and uncomment to run the examples
 	// // id := ExampleCreateInstance() // uncomment to create a new instance
 	// // id := ExampleListInstances() // uncomment to list instances and get the id of the last instance
@@ -261,14 +295,14 @@ func ExampleListImagesWithJWT() {
 		fmt.Printf("  Minimum Requirements: %d VCPUs, %d RAM, %d Disk\n", image.MinimumRequirements.VCPU, image.MinimumRequirements.RAM, image.MinimumRequirements.Disk)
 	}
 }
-func ExampleListImagesWithJWTAndAPIKey() {
-	c := client.NewMgcClient(client.WithAPIKey("057dca55-6115-API-KEY-f03f8e1adbb2"), client.WithJWToken("Bearer JWTokenn"))
+func ExampleListImagesWithJWTAndAPIKey(ctx context.Context, apiToken string) {
+	c := client.NewMgcClient(client.WithAPIKey(apiToken), client.WithJWToken("Bearer JWToken"))
 	computeClient := compute.New(c)
 
 	// List images
-	_, err := computeClient.Images().List(context.Background(), compute.ImageListOptions{})
+	_, err := computeClient.Images().List(ctx, compute.ImageListOptions{})
 	if err != nil {
-		log.Println("Successfully authenticated with API Key and ignored JWT authentication")
+		log.Println("Failed to authenticate with API Key and ignore JWT authentication")
 		log.Fatal(err)
 	}
 }
@@ -394,3 +428,26 @@ func awaitRunningCompleted(id string) {
 	fmt.Println("Instance is running")
 }
 */
+
+func ExampleCreateCustomImage(ctx context.Context, cli *compute.VirtualMachineClient) {
+	url := os.Getenv("MGC_SIGNED_IMG_URL")
+	if url == "" {
+		fmt.Println("MGC_SIGNED_IMG_URL environment variable not set, skipping custom image creation")
+		return
+	}
+
+	req := compute.CreateCustomImageRequest{
+		Name:         "sdk-example-" + time.Now().Format("20060102150405"),
+		Platform:     compute.PlatformLinux,
+		Architecture: compute.ArchitectureX86_64,
+		License:      compute.LicenseUnlicensed,
+		URL:          url,
+	}
+	id, err := cli.Images().CreateCustom(ctx, req)
+	if err != nil {
+		fmt.Printf("Failed to create custom image: %s\n", err)
+		return
+	}
+
+	fmt.Printf("Image ID: %s\n", id)
+}

--- a/compute/images.go
+++ b/compute/images.go
@@ -54,11 +54,46 @@ const (
 	ImageStatusDeletingError ImageStatus = "deleting_error"
 )
 
+// Platform represents the system platform.
+type Platform string
+
+const (
+	PlatformLinux   Platform = "linux"
+	PlatformWindows Platform = "windows"
+)
+
+// Architecture represents the system architecure.
+type Architecture string
+
+const ArchitectureX86_64 Architecture = "x86/64"
+
+// License indicates if the image software requires a license.
+type License string
+
+const (
+	LicenseLicensed   License = "licensed"
+	LicenseUnlicensed License = "unlicensed"
+)
+
+// CreateCustomImageRequest represents the request to create a new custom image.
+type CreateCustomImageRequest struct {
+	Name         string               `json:"name"`
+	Platform     Platform             `json:"platform"`
+	Architecture Architecture         `json:"architecture"`
+	License      License              `json:"license"`
+	URL          string               `json:"url"`
+	Requirements *MinimumRequirements `json:"requirements,omitempty"`
+	Version      *string              `json:"version,omitempty"`
+	Description  *string              `json:"description,omitempty"`
+	UEFI         *bool                `json:"uefi,omitempty"`
+}
+
 // ImageService provides operations for managing virtual machine images.
 // This interface allows listing available images with optional filtering.
 type ImageService interface {
 	List(ctx context.Context, opts ImageListOptions) (*ImageList, error)
 	ListAll(ctx context.Context, opts ImageFilterOptions) ([]Image, error)
+	CreateCustom(ctx context.Context, req CreateCustomImageRequest) (string, error)
 }
 
 // imageService implements the ImageService interface.
@@ -149,4 +184,23 @@ func (s *imageService) ListAll(ctx context.Context, opts ImageFilterOptions) ([]
 	}
 
 	return allImages, nil
+}
+
+// Create creates a new custom image.
+// This method makes an HTTP request to publish a new custom image
+// and returns the ID of the created image.
+func (s *imageService) CreateCustom(ctx context.Context, createReq CreateCustomImageRequest) (string, error) {
+	res, err := mgc_http.ExecuteSimpleRequestWithRespBody[struct{ ID string }](
+		ctx,
+		s.client.newRequest,
+		s.client.GetConfig(),
+		http.MethodPost,
+		"/v1/images/custom",
+		createReq,
+		nil,
+	)
+	if err != nil {
+		return "", err
+	}
+	return res.ID, nil
 }

--- a/compute/images_test.go
+++ b/compute/images_test.go
@@ -334,3 +334,103 @@ func generateImageListJSON(start, count int) string {
 	}
 	return result
 }
+
+func TestImageService_CreateCustom(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name       string
+		req        CreateCustomImageRequest
+		response   string
+		statusCode int
+		wantID     string
+		wantErr    bool
+	}{
+		{
+			name: "successful creation",
+			req: CreateCustomImageRequest{
+				Name:         "test-image",
+				Platform:     PlatformLinux,
+				Architecture: ArchitectureX86_64,
+				License:      LicenseUnlicensed,
+				URL:          "https://br-se1.magaluobjects.com/bucket/image.qcow2",
+			},
+			response:   `{"id": "8cf5c6d9-d5c5-4af9-bd1b-c17d032dc761"}`,
+			statusCode: http.StatusOK,
+			wantID:     "8cf5c6d9-d5c5-4af9-bd1b-c17d032dc761",
+			wantErr:    false,
+		},
+		{
+			name: "empty name",
+			req: CreateCustomImageRequest{
+				Platform:     PlatformLinux,
+				Architecture: ArchitectureX86_64,
+				License:      LicenseUnlicensed,
+				URL:          "https://br-se1.magaluobjects.com/bucket/image.qcow2",
+			},
+			response:   `{"error": "name is required"}`,
+			statusCode: http.StatusBadRequest,
+			wantErr:    true,
+		},
+		{
+			name: "invalid architecture",
+			req: CreateCustomImageRequest{
+				Name:         "test-image",
+				Platform:     PlatformLinux,
+				Architecture: Architecture("arm64"),
+				License:      LicenseUnlicensed,
+				URL:          "https://br-se1.magaluobjects.com/bucket/image.qcow2",
+			},
+			response:   `{"error": "invalid architecture"}`,
+			statusCode: http.StatusBadRequest,
+			wantErr:    true,
+		},
+		{
+			name: "server error",
+			req: CreateCustomImageRequest{
+				Name:         "test-image",
+				Platform:     PlatformLinux,
+				Architecture: ArchitectureX86_64,
+				License:      LicenseUnlicensed,
+				URL:          "https://br-se1.magaluobjects.com/bucket/image.qcow2",
+			},
+			response:   `{"error": "internal error"}`,
+			statusCode: http.StatusInternalServerError,
+			wantErr:    true,
+		},
+		{
+			name: "duplicate name",
+			req: CreateCustomImageRequest{
+				Name:         "test-duplicated-image",
+				Platform:     PlatformLinux,
+				Architecture: ArchitectureX86_64,
+				License:      LicenseUnlicensed,
+				URL:          "https://br-se1.magaluobjects.com/bucket/image.qcow2",
+			},
+			response:   `{"error": "image name already exists"}`,
+			statusCode: http.StatusConflict,
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tt.statusCode)
+				w.Write([]byte(tt.response))
+			}))
+			defer server.Close()
+
+			client := testClient(server.URL)
+			gotID, err := client.Images().CreateCustom(context.Background(), tt.req)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Create() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if gotID != tt.wantID {
+				t.Errorf("Create() got = %v, want %v", gotID, tt.wantID)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What does this PR do?
Adiciona suporte para a criação de imagens customizadas. #169 

## How Has This Been Tested?
Além dos testes de unidade o programa de exemplo abaixo foi utilizado para fins de teste.
```go
// main.go
package main

import (
	"context"
	"fmt"
	"os"

	"github.com/MagaluCloud/mgc-sdk-go/client"
	"github.com/MagaluCloud/mgc-sdk-go/compute"
)

var apiKey = os.Getenv("MGC_API_KEY")

func main() {
	if len(os.Args) != 2 {
		fmt.Fprintf(os.Stderr, "usage: %s <signed-url>\n", os.Args[0])
		os.Exit(1)
	}

	cli := compute.New(client.NewMgcClient(client.WithAPIKey(apiKey), client.WithBaseURL(client.BrSe1)))
	req := compute.CreateCustomImageRequest{
		Name:         "sdk-test",
		Platform:     compute.PlatformLinux,
		Architecture: compute.ArchitectureX86_64,
		License:      compute.LicenseUnlicensed,
		URL:          os.Args[1],
	}
	id, err := cli.Images().CreateCustom(context.Background(), req)
	if err != nil {
		fmt.Fprintf(os.Stderr, "failed to create custom image: %s\n", err)
		os.Exit(1)
	}

	fmt.Printf("Image ID: %s\n", id)
}
```
Para executar o programa de teste é necessário um token de API e URL assinada para uma imagem salva no serviço Object Storage da MGC.
```sh
MGC_API_KEY='...' go run main.go 'https://br-se1.magaluobjects.com/...'
```
É possível confirmar a criação da imagem via CLI utilizando o comando abaixo:
```sh
mgc vm images custom get <id>
```

## Checklist
- [x] My code follows the style guidelines of this project
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
