### PR TITLE
feat: add method to retrieve custom image by id

### DIFF
--- a/cmd/examples/compute/main.go
+++ b/cmd/examples/compute/main.go
@@ -49,7 +49,8 @@ func main() {
 	// ExampleListImages()
 	ExampleListImagesWithJWT()
 	ExampleListImagesWithJWTAndAPIKey(ctx, apiToken)
-	ExampleCreateCustomImage(ctx, cli)
+	id := ExampleCreateCustomImage(ctx, cli)
+	ExampleRetrieveCustomImage(ctx, cli, id)
 	// id := "" // comment and uncomment to run the examples
 	// // id := ExampleCreateInstance() // uncomment to create a new instance
 	// // id := ExampleListInstances() // uncomment to list instances and get the id of the last instance
@@ -429,7 +430,7 @@ func awaitRunningCompleted(id string) {
 }
 */
 
-func ExampleCreateCustomImage(ctx context.Context, cli *compute.VirtualMachineClient) {
+func ExampleCreateCustomImage(ctx context.Context, cli *compute.VirtualMachineClient) (id string) {
 	url := os.Getenv("MGC_SIGNED_IMG_URL")
 	if url == "" {
 		fmt.Println("MGC_SIGNED_IMG_URL environment variable not set, skipping custom image creation")
@@ -450,4 +451,33 @@ func ExampleCreateCustomImage(ctx context.Context, cli *compute.VirtualMachineCl
 	}
 
 	fmt.Printf("Image ID: %s\n", id)
+	return
+}
+
+func ExampleRetrieveCustomImage(ctx context.Context, cli *compute.VirtualMachineClient, id string) {
+	if id == "" {
+		fmt.Println("Custom image ID not set, skipping custom image request")
+		return
+	}
+
+	image, err := cli.Images().GetCustom(ctx, id)
+	if err != nil {
+		fmt.Printf("Failed to retrieve custom image: %s\n", err)
+		return
+	}
+
+	fmt.Printf("Image: %s (ID: %s)\n", image.Name, image.ID)
+	fmt.Printf("  Status: %s\n", image.Status)
+	fmt.Printf("  Platform: %s\n", image.Platform)
+	fmt.Printf("  License: %s\n", image.License)
+	fmt.Printf("  Requirements: %d vCPU, %d RAM, %d Disk\n", image.Requirements.VCPU, image.Requirements.RAM, image.Requirements.Disk)
+	if image.Version != nil {
+		fmt.Printf("  Version: %s\n", *image.Version)
+	}
+	if image.Description != nil {
+		fmt.Printf("  Description: %s\n", *image.Description)
+	}
+	if image.Metadata != nil {
+		fmt.Printf("  Metadata: %v\n", *image.Metadata)
+	}
 }

--- a/compute/images.go
+++ b/compute/images.go
@@ -2,6 +2,7 @@ package compute
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"strconv"
 
@@ -44,14 +45,17 @@ type MinimumRequirements struct {
 type ImageStatus string
 
 const (
-	ImageStatusActive        ImageStatus = "active"
-	ImageStatusDeprecated    ImageStatus = "deprecated"
-	ImageStatusDeleted       ImageStatus = "deleted"
-	ImageStatusPending       ImageStatus = "pending"
-	ImageStatusCreating      ImageStatus = "creating"
-	ImageStatusImporting     ImageStatus = "importing"
-	ImageStatusError         ImageStatus = "error"
-	ImageStatusDeletingError ImageStatus = "deleting_error"
+	ImageStatusActive         ImageStatus = "active"
+	ImageStatusDeprecated     ImageStatus = "deprecated"
+	ImageStatusDeleted        ImageStatus = "deleted"
+	ImageStatusDeleting       ImageStatus = "deleting"
+	ImageStatusDeletingError  ImageStatus = "deleting_error"
+	ImageStatusPending        ImageStatus = "pending"
+	ImageStatusCreating       ImageStatus = "creating"
+	ImageStatusImporting      ImageStatus = "importing"
+	ImageStatusImportingError ImageStatus = "importing_error"
+	ImageStatusInvalidImage   ImageStatus = "invalid_image"
+	ImageStatusError          ImageStatus = "error"
 )
 
 // Platform represents the system platform.
@@ -88,12 +92,27 @@ type CreateCustomImageRequest struct {
 	UEFI         *bool                `json:"uefi,omitempty"`
 }
 
+// CustomImage represents a custom virtual machine image.
+// An image is a template that contains the operating system and software for creating instances.
+type CustomImage struct {
+	ID           string               `json:"id"`
+	Name         string               `json:"name"`
+	Status       ImageStatus          `json:"status"`
+	Platform     Platform             `json:"platform"`
+	License      License              `json:"license"`
+	Requirements *MinimumRequirements `json:"requirements,omitempty"`
+	Version      *string              `json:"version,omitempty"`
+	Description  *string              `json:"description,omitempty"`
+	Metadata     *map[string]any      `json:"metadata,omitempty"`
+}
+
 // ImageService provides operations for managing virtual machine images.
 // This interface allows listing available images with optional filtering.
 type ImageService interface {
 	List(ctx context.Context, opts ImageListOptions) (*ImageList, error)
 	ListAll(ctx context.Context, opts ImageFilterOptions) ([]Image, error)
 	CreateCustom(ctx context.Context, req CreateCustomImageRequest) (string, error)
+	GetCustom(ctx context.Context, id string) (*CustomImage, error)
 }
 
 // imageService implements the ImageService interface.
@@ -203,4 +222,18 @@ func (s *imageService) CreateCustom(ctx context.Context, createReq CreateCustomI
 		return "", err
 	}
 	return res.ID, nil
+}
+
+// GetCustom retrieves a specific custom image.
+// This method makes an HTTP request to get detailed information about an image.
+func (s *imageService) GetCustom(ctx context.Context, id string) (*CustomImage, error) {
+	return mgc_http.ExecuteSimpleRequestWithRespBody[CustomImage](
+		ctx,
+		s.client.newRequest,
+		s.client.GetConfig(),
+		http.MethodGet,
+		fmt.Sprintf("/v1/images/custom/%s", id),
+		nil,
+		nil,
+	)
 }

--- a/compute/images_test.go
+++ b/compute/images_test.go
@@ -434,3 +434,84 @@ func TestImageService_CreateCustom(t *testing.T) {
 		})
 	}
 }
+
+func TestImageService_GetCustom(t *testing.T) {
+	tests := []struct {
+		name       string
+		id         string
+		response   string
+		statusCode int
+		wantErr    bool
+	}{
+		{
+			name: "successful request",
+			id:   "86a304b0-dc28-454e-9448-5275c4008dfa",
+			response: `{
+				 "id": "86a304b0-dc28-454e-9448-5275c4008dfa",
+				 "name": "test",
+				 "status": "active",
+				 "platform": "linux",
+				 "license": "unlicensed",
+				 "requirements": {
+				  "vcpu": 1,
+				  "ram": 1,
+				  "disk": 3
+				 },
+				 "version": "1.0.0",
+				 "description": "Test",
+				 "metadata": {
+				  "uefi": "true"
+				 }
+			}`,
+			statusCode: http.StatusOK,
+			wantErr:    false,
+		},
+		{
+			name:       "image not found",
+			id:         "a0db5832-3767-4335-8a89-9b46ce636790",
+			response:   `{"message": "Image not found"}`,
+			statusCode: http.StatusNotFound,
+			wantErr:    true,
+		},
+		{
+			name:       "server error",
+			id:         "86a304b0-dc28-454e-9448-5275c4008dfa",
+			response:   `{"message": "Internal server error"}`,
+			statusCode: http.StatusInternalServerError,
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(
+				http.HandlerFunc(
+					func(w http.ResponseWriter, r *http.Request) {
+						w.Header().Set("Content-Type", "application/json")
+						w.WriteHeader(tt.statusCode)
+						w.Write([]byte(tt.response))
+					},
+				),
+			)
+			defer server.Close()
+
+			client := testClient(server.URL)
+			got, err := client.Images().GetCustom(context.Background(), tt.id)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("GetCustom() expected erro, got nil")
+					return
+				}
+			} else {
+				if err != nil {
+					t.Errorf("GetCustom() unexpected error: %v", err)
+					return
+				}
+				if got.ID != tt.id {
+					t.Errorf("GetCustom() got ID %s, want %s", got.ID, tt.id)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What does this PR do?
Adiciona suporte para visualizar uma imagem customizada. #169

## How Has This Been Tested?
Além dos testes de unidade o programa de exemplo abaixo foi utilizado para fins de teste.
```go
// main.go
package main

import (
	"context"
	"encoding/json"
	"fmt"
	"os"

	"github.com/MagaluCloud/mgc-sdk-go/client"
	"github.com/MagaluCloud/mgc-sdk-go/compute"
)

var apiKey = os.Getenv("MGC_API_KEY")

func main() {
	if len(os.Args) != 2 {
		fmt.Fprintf(os.Stderr, "usage: %s <custom-image-id>\n", os.Args[0])
		os.Exit(1)
	}

	cli := compute.New(client.NewMgcClient(client.WithAPIKey(apiKey), client.WithBaseURL(client.BrSe1)))
	img, err := cli.Images().GetCustom(context.Background(), os.Args[1])
	if err != nil {
		fmt.Fprintf(os.Stderr, "failed to retrieve custom image: %s\n", err)
		os.Exit(1)
	}

	out, _ := json.MarshalIndent(img, "", "  ")
	fmt.Println(string(out))
}
```
Para executar o programa de teste é necessário um token de API e URL assinada para uma imagem salva no serviço Object Storage da MGC.
```sh
MGC_API_KEY='...' go run main.go 10173e11-f471-406d-a9e4-d85ec2012a8c
```
O retorno deve ser algo similar ao exemplo abaixo:
```json
{
  "id": "10173e11-f471-406d-a9e4-d85ec2012a8c",
  "name": "sdk-test",
  "status": "active",
  "platform": "linux",
  "license": "unlicensed",
  "requirements": {
    "vcpu": 1,
    "ram": 1,
    "disk": 1
  },
  "metadata": {
    "uefi": "false"
  }
}
```

## Checklist
- [x] My code follows the style guidelines of this project
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
