### PR TITLE
feat: add method to delete custom images

### DIFF
--- a/cmd/examples/compute/main.go
+++ b/cmd/examples/compute/main.go
@@ -53,6 +53,8 @@ func main() {
 	id := ExampleCreateCustomImage(ctx, cli)
 	ExampleRetrieveCustomImage(ctx, cli, id)
 	ExampleListCustomImages(ctx, cli)
+	time.Sleep(5 * time.Second)
+	ExampleDeleteCustomImage(ctx, cli, id)
 	// id := "" // comment and uncomment to run the examples
 	// // id := ExampleCreateInstance() // uncomment to create a new instance
 	// // id := ExampleListInstances() // uncomment to list instances and get the id of the last instance
@@ -508,4 +510,19 @@ func ExampleListCustomImages(ctx context.Context, cli *compute.VirtualMachineCli
 			fmt.Printf("  Metadata: %v\n", *image.Metadata)
 		}
 	}
+}
+
+func ExampleDeleteCustomImage(ctx context.Context, cli *compute.VirtualMachineClient, id string) {
+	if id == "" {
+		fmt.Println("Custom image ID not set, skipping custom image deletion request")
+		return
+	}
+
+	err := cli.Images().DeleteCustom(ctx, id)
+	if err != nil {
+		fmt.Printf("Failed to delete custom image: %s\n", err)
+		return
+	}
+
+	fmt.Printf("Image ID: %s deletion succeeded\n", id)
 }

--- a/compute/images.go
+++ b/compute/images.go
@@ -130,6 +130,7 @@ type ImageService interface {
 	CreateCustom(ctx context.Context, req CreateCustomImageRequest) (string, error)
 	GetCustom(ctx context.Context, id string) (*CustomImage, error)
 	ListCustom(ctx context.Context, opts CustomImageListOptions) (*CustomImageList, error)
+	DeleteCustom(ctx context.Context, id string) error
 }
 
 // imageService implements the ImageService interface.
@@ -287,4 +288,18 @@ func (s *imageService) ListCustom(ctx context.Context, opts CustomImageListOptio
 	}
 
 	return response, nil
+}
+
+// DeleteCustom deletes a specific custom image.
+// This method makes an HTTP request to delete the specified image.
+func (s *imageService) DeleteCustom(ctx context.Context, id string) error {
+	return mgc_http.ExecuteSimpleRequest(
+		ctx,
+		s.client.newRequest,
+		s.client.GetConfig(),
+		http.MethodDelete,
+		fmt.Sprintf("/v1/images/custom/%s", id),
+		nil,
+		nil,
+	)
 }

--- a/compute/images_test.go
+++ b/compute/images_test.go
@@ -682,3 +682,61 @@ func TestImageService_ListCustom(t *testing.T) {
 		})
 	}
 }
+
+func TestImageService_DeleteCustom(t *testing.T) {
+	tests := []struct {
+		name       string
+		id         string
+		response   string
+		statusCode int
+		wantErr    bool
+	}{
+		{
+			name:       "successful request",
+			id:         "86a304b0-dc28-454e-9448-5275c4008dfa",
+			statusCode: http.StatusNoContent,
+			wantErr:    false,
+		},
+		{
+			name:       "image not found",
+			id:         "a0db5832-3767-4335-8a89-9b46ce636790",
+			response:   `{"message": "Image with id a0db5832-3767-4335-8a89-9b46ce636790 not found"}`,
+			statusCode: http.StatusNotFound,
+			wantErr:    true,
+		},
+		{
+			name:       "server error",
+			id:         "86a304b0-dc28-454e-9448-5275c4008dfa",
+			response:   `{"message": "Internal server error"}`,
+			statusCode: http.StatusInternalServerError,
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(
+				http.HandlerFunc(
+					func(w http.ResponseWriter, r *http.Request) {
+						w.Header().Set("Content-Type", "application/json")
+						w.WriteHeader(tt.statusCode)
+						w.Write([]byte(tt.response))
+					},
+				),
+			)
+			defer server.Close()
+
+			client := testClient(server.URL)
+			err := client.Images().DeleteCustom(context.Background(), tt.id)
+
+			if tt.wantErr && err == nil {
+				t.Errorf("DeleteCustom() expected erro, got nil")
+				return
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("DeleteCustom() unexpected error: %v", err)
+				return
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What does this PR do?
Adiciona suporte para excluir uma imagem customizada. #169

## How Has This Been Tested?
Além dos testes de unidade o programa de exemplo em `cmd/examples/compute` foi utilizado para fins de teste.

## Checklist
- [x] My code follows the style guidelines of this project
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
