### PR TITLE
feat: add method for object storage client to generate presigned urls

### DIFF
--- a/cmd/examples/objectstorage/main.go
+++ b/cmd/examples/objectstorage/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"net/http"
 	"os"
 	"strings"
 	"time"
@@ -142,11 +143,15 @@ func runE2ETest(ctx context.Context, osClient *objectstorage.ObjectStorageClient
 	testDeleteBucketCORS(ctx, osClient)
 	pause()
 
-	// Step 16: Delete object
+	// Step 16: Get presigned URL
+	testGetPresignedURL(ctx, osClient)
+	pause()
+
+	// Step 17: Delete object
 	testDeleteObject(ctx, osClient)
 	pause()
 
-	// Step 17: Delete bucket
+	// Step 18: Delete bucket
 	testDeleteBucket(ctx, osClient)
 	pause()
 
@@ -464,8 +469,36 @@ func testDeleteBucketCORS(ctx context.Context, osClient *objectstorage.ObjectSto
 	fmt.Printf("✅ Bucket cors deleted successfully\n\n")
 }
 
+func testGetPresignedURL(ctx context.Context, osClient *objectstorage.ObjectStorageClient) {
+	fmt.Println("📝 Test 16: Get presigned URL")
+	fmt.Println("─────────────────────────────────────────────────────────────")
+
+	presignedURL, err := osClient.Objects().GetPresignedURL(ctx, testBucketName, testObjectKey, objectstorage.GetPresignedURLOptions{
+		Method: http.MethodGet,
+	})
+	if err != nil {
+		fmt.Printf("❌ Failed to get presigned GET URL: %v\n\n", err)
+		return
+	}
+
+	fmt.Printf("✅ Presigned GET URL retrieved: %s\n\n", presignedURL.URL)
+
+	expiry := 10 * time.Minute
+
+	presignedURL, err = osClient.Objects().GetPresignedURL(ctx, testBucketName, testObjectKey, objectstorage.GetPresignedURLOptions{
+		Method:          http.MethodPut,
+		ExpiryInSeconds: &expiry,
+	})
+	if err != nil {
+		fmt.Printf("❌ Failed to get presigned PUT URL: %v\n\n", err)
+		return
+	}
+
+	fmt.Printf("✅ Presigned PUT URL retrieved: %s\n\n", presignedURL.URL)
+}
+
 func testDeleteObject(ctx context.Context, osClient *objectstorage.ObjectStorageClient) {
-	fmt.Println("📝 Test 16: Delete Object")
+	fmt.Println("📝 Test 17: Delete Object")
 	fmt.Println("─────────────────────────────────────────────────────────────")
 
 	err := osClient.Objects().Delete(ctx, testBucketName, testObjectKey, nil)
@@ -478,7 +511,7 @@ func testDeleteObject(ctx context.Context, osClient *objectstorage.ObjectStorage
 }
 
 func testDeleteBucket(ctx context.Context, osClient *objectstorage.ObjectStorageClient) {
-	fmt.Println("📝 Test 17: Delete Bucket")
+	fmt.Println("📝 Test 18: Delete Bucket")
 	fmt.Println("─────────────────────────────────────────────────────────────")
 
 	err := osClient.Buckets().Delete(ctx, testBucketName, true)

--- a/objectstorage/minio_interface.go
+++ b/objectstorage/minio_interface.go
@@ -3,6 +3,7 @@ package objectstorage
 import (
 	"context"
 	"io"
+	"net/url"
 	"time"
 
 	"github.com/minio/minio-go/v7"
@@ -36,6 +37,8 @@ type minioClientInterface interface {
 	PutObjectRetention(ctx context.Context, bucketName string, objectName string, opts minio.PutObjectRetentionOptions) error
 	GetObjectRetention(ctx context.Context, bucketName string, objectName string, versionID string) (*minio.RetentionMode, *time.Time, error)
 	SetAppInfo(appName string, appVersion string)
+	PresignedGetObject(ctx context.Context, bucketName string, objectName string, expiry time.Duration, reqParams url.Values) (*url.URL, error)
+	PresignedPutObject(ctx context.Context, bucketName string, objectName string, expiry time.Duration) (*url.URL, error)
 }
 
 // Ensure *minio.Client implements minioClientInterface

--- a/objectstorage/mock_minio_test.go
+++ b/objectstorage/mock_minio_test.go
@@ -3,6 +3,7 @@ package objectstorage
 import (
 	"context"
 	"io"
+	"net/url"
 	"time"
 
 	"github.com/minio/minio-go/v7"
@@ -33,6 +34,8 @@ type mockMinioClient struct {
 	statObjectFunc         func(ctx context.Context, bucketName string, objectName string, opts minio.StatObjectOptions) (minio.ObjectInfo, error)
 	putObjectRetentionFunc func(ctx context.Context, bucketName string, objectName string, opts minio.PutObjectRetentionOptions) error
 	getObjectRetentionFunc func(ctx context.Context, bucketName string, objectName string, versionID string) (*minio.RetentionMode, *time.Time, error)
+	presignedGetObjectFunc func(ctx context.Context, bucketName string, objectName string, expiry time.Duration, reqParams url.Values) (*url.URL, error)
+	presignedPutObjectFunc func(ctx context.Context, bucketName string, objectName string, expiry time.Duration) (*url.URL, error)
 	setAppInfoCalls        int
 	lastAppName            string
 	lastAppVersion         string
@@ -403,6 +406,56 @@ func (m *mockMinioClient) GetObjectRetention(ctx context.Context, bucketName str
 	}
 
 	return obj.retention.mode, obj.retention.retainUntilDate, nil
+}
+
+func (m *mockMinioClient) PresignedGetObject(ctx context.Context, bucketName string, objectName string, expiry time.Duration, reqParams url.Values) (*url.URL, error) {
+	if m.presignedGetObjectFunc != nil {
+		return m.presignedGetObjectFunc(ctx, bucketName, objectName, expiry, reqParams)
+	}
+
+	bucket, exists := m.buckets[bucketName]
+	if !exists {
+		return nil, nil
+	}
+
+	obj, exists := bucket.objects[objectName]
+	if !exists {
+		return nil, nil
+	}
+
+	mockURL := "https://mock-minio/" + bucketName + "/" + obj.key + "?expiry=" + expiry.String()
+
+	parsedURL, err := url.Parse(mockURL)
+	if err != nil {
+		return nil, err
+	}
+
+	return parsedURL, nil
+}
+
+func (m *mockMinioClient) PresignedPutObject(ctx context.Context, bucketName string, objectName string, expiry time.Duration) (*url.URL, error) {
+	if m.presignedPutObjectFunc != nil {
+		return m.presignedPutObjectFunc(ctx, bucketName, objectName, expiry)
+	}
+
+	bucket, exists := m.buckets[bucketName]
+	if !exists {
+		return nil, nil
+	}
+
+	obj, exists := bucket.objects[objectName]
+	if !exists {
+		return nil, nil
+	}
+
+	mockURL := "https://mock-minio/" + bucketName + "/" + obj.key + "?expiry=" + expiry.String()
+
+	parsedURL, err := url.Parse(mockURL)
+	if err != nil {
+		return nil, err
+	}
+
+	return parsedURL, nil
 }
 
 func (m *mockMinioClient) SetAppInfo(appName string, appVersion string) {

--- a/objectstorage/objects.go
+++ b/objectstorage/objects.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"context"
 	"io"
+	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/minio/minio-go/v7"
@@ -23,11 +25,26 @@ type ObjectService interface {
 	LockObject(ctx context.Context, bucketName string, objectKey string, retainUntilDate time.Time) error
 	UnlockObject(ctx context.Context, bucketName string, objectKey string) error
 	GetObjectLockStatus(ctx context.Context, bucketName string, objectKey string) (bool, error)
+	GetPresignedURL(ctx context.Context, bucketName string, objectKey string, opts GetPresignedURLOptions) (*PresignedURL, error)
 }
 
 // objectService implements the ObjectService interface.
 type objectService struct {
 	client *ObjectStorageClient
+}
+
+func validateBucket(bucket string) error {
+	if bucket == "" {
+		return &InvalidBucketNameError{Name: bucket}
+	}
+	return nil
+}
+
+func validateObjectKey(key string) error {
+	if key == "" {
+		return &InvalidObjectKeyError{Key: key}
+	}
+	return nil
 }
 
 // Upload uploads an object to a bucket.
@@ -359,4 +376,40 @@ func (s *objectService) ListVersions(ctx context.Context, bucketName string, obj
 	}
 
 	return result, nil
+}
+
+func (s *objectService) GetPresignedURL(ctx context.Context, bucketName string, objectKey string, opts GetPresignedURLOptions) (*PresignedURL, error) {
+	if err := validateBucket(bucketName); err != nil {
+		return nil, err
+	}
+
+	if err := validateObjectKey(objectKey); err != nil {
+		return nil, err
+	}
+
+	if opts.Method != http.MethodGet && opts.Method != http.MethodPut {
+		return nil, &InvalidObjectDataError{Message: "Invalid HTTP method"}
+	}
+
+	var presignedURL *url.URL
+	var err error
+
+	expiryInSeconds := 5 * time.Minute
+
+	if opts.ExpiryInSeconds != nil {
+		expiryInSeconds = *opts.ExpiryInSeconds
+	}
+
+	switch opts.Method {
+	case http.MethodGet:
+		presignedURL, err = s.client.minioClient.PresignedGetObject(ctx, bucketName, objectKey, expiryInSeconds, url.Values{})
+	case http.MethodPut:
+		presignedURL, err = s.client.minioClient.PresignedPutObject(ctx, bucketName, objectKey, expiryInSeconds)
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &PresignedURL{URL: presignedURL.String()}, nil
 }

--- a/objectstorage/objects_test.go
+++ b/objectstorage/objects_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"io"
+	"net/http"
 	"testing"
 	"time"
 
@@ -1228,4 +1229,115 @@ func TestListVersionsOptions(t *testing.T) {
 
 func intPtr(v int) *int {
 	return &v
+}
+
+func TestObjectServiceGetPresignedURL_InvalidBucketName(t *testing.T) {
+	t.Parallel()
+
+	core := client.NewMgcClient()
+	osClient, _ := New(core, "minioadmin", "minioadmin")
+	svc := osClient.Objects()
+
+	_, err := svc.GetPresignedURL(context.Background(), "", "test-key", GetPresignedURLOptions{
+		Method: http.MethodGet,
+	})
+
+	if err == nil {
+		t.Error("GetPresignedURL() expected error for empty bucket name, got nil")
+	}
+
+	if _, ok := err.(*InvalidBucketNameError); !ok {
+		t.Errorf("GetPresignedURL() expected InvalidBucketNameError, got %T", err)
+	}
+}
+
+func TestObjectServiceGetPresignedURL_InvalidObjectKey(t *testing.T) {
+	t.Parallel()
+
+	core := client.NewMgcClient()
+	osClient, _ := New(core, "minioadmin", "minioadmin")
+	svc := osClient.Objects()
+
+	_, err := svc.GetPresignedURL(context.Background(), "test-bucket", "", GetPresignedURLOptions{
+		Method: http.MethodGet,
+	})
+
+	if err == nil {
+		t.Error("GetPresignedURL() expected error for empty object key, got nil")
+	}
+
+	if _, ok := err.(*InvalidObjectKeyError); !ok {
+		t.Errorf("GetPresignedURL() expected InvalidObjectKeyError, got %T", err)
+	}
+}
+
+func TestObjectServiceGetPresignedURL_InvalidMethod(t *testing.T) {
+	t.Parallel()
+
+	core := client.NewMgcClient()
+	osClient, _ := New(core, "minioadmin", "minioadmin")
+	svc := osClient.Objects()
+
+	_, err := svc.GetPresignedURL(context.Background(), "test-bucket", "test-object", GetPresignedURLOptions{
+		Method: http.MethodPost,
+	})
+
+	if err == nil {
+		t.Error("GetPresignedURL() expected error for invalid method, got nil")
+	}
+
+	if _, ok := err.(*InvalidObjectDataError); !ok {
+		t.Errorf("GetPresignedURL() expected InvalidObjectDataError, got %T", err)
+	}
+}
+
+func TestObjectServiceGetPresignedURL_PUTMethod(t *testing.T) {
+	t.Parallel()
+
+	core := client.NewMgcClient()
+	osClient, _ := New(core, "minioadmin", "minioadmin")
+	svc := osClient.Objects()
+
+	_, err := svc.GetPresignedURL(context.Background(), "test-bucket", "test-key", GetPresignedURLOptions{
+		Method: http.MethodPut,
+	})
+
+	if err != nil {
+		t.Error("GetPresignedURL() expected presigned URL, got nil")
+	}
+}
+
+func TestObjectServiceGetPresignedURL_GETMethod(t *testing.T) {
+	t.Parallel()
+
+	core := client.NewMgcClient()
+	osClient, _ := New(core, "minioadmin", "minioadmin")
+	svc := osClient.Objects()
+
+	_, err := svc.GetPresignedURL(context.Background(), "test-bucket", "test-key", GetPresignedURLOptions{
+		Method: http.MethodGet,
+	})
+
+	if err != nil {
+		t.Error("GetPresignedURL() expected presigned URL, got nil")
+	}
+}
+
+func TestObjectServiceGetPresignedURL_WithExpiry(t *testing.T) {
+	t.Parallel()
+
+	core := client.NewMgcClient()
+	osClient, _ := New(core, "minioadmin", "minioadmin")
+	svc := osClient.Objects()
+
+	expire := 5 * time.Minute
+
+	_, err := svc.GetPresignedURL(context.Background(), "test-bucket", "test-key", GetPresignedURLOptions{
+		Method:          http.MethodPut,
+		ExpiryInSeconds: &expire,
+	})
+
+	if err != nil {
+		t.Error("GetPresignedURL() expected presigned URL, got nil")
+	}
 }

--- a/objectstorage/types.go
+++ b/objectstorage/types.go
@@ -114,3 +114,12 @@ type ListVersionsOptions struct {
 	Limit  *int `json:"_limit,omitempty"`
 	Offset *int `json:"_offset,omitempty"`
 }
+
+type GetPresignedURLOptions struct {
+	Method          string         `json:"method,omitempty"`
+	ExpiryInSeconds *time.Duration `json:"expiry_in_seconds,omitempty"`
+}
+
+type PresignedURL struct {
+	URL string `json:"url"`
+}


### PR DESCRIPTION
## What does this PR do?
Adiciona ao cliente do serviço Object Storage suporte para geração de URLs assinadas para acessar e criar objetos.

O código foi extraído do PR #161 

## How Has This Been Tested?
Foram adicionados testes de unidade e um exemplo de utilização em `cmd/examples/objectstorage/main.go`.

## Checklist
- [x] My code follows the style guidelines of this project
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
