### PR TITLE
feat: add support for creating instances with multiple VNICs

### DIFF
--- a/cmd/examples/compute/main.go
+++ b/cmd/examples/compute/main.go
@@ -193,6 +193,72 @@ func ExampleCreateInstance() string {
 */
 
 /*
+// ExampleCreateInstanceWithMultipleVNICs demonstrates creating an instance with
+// multiple network interfaces (VNICs) using the network_profile field.
+// Up to 3 interfaces are supported. Use the "tag" field to reliably identify
+// each interface from the guest OS, since network device order is not guaranteed.
+func ExampleCreateInstanceWithMultipleVNICs() string {
+	apiToken := os.Getenv("MGC_API_TOKEN")
+	if apiToken == "" {
+		log.Fatal("MGC_API_TOKEN environment variable is not set")
+	}
+	c := client.NewMgcClient(client.WithAPIKey(apiToken))
+	computeClient := compute.New(c)
+
+	userData := "#!/bin/bash\necho \"Hello World\"\n"
+	base64UserData := base64.StdEncoding.EncodeToString([]byte(userData))
+	date := time.Now().Format("2006-01-02-15-04-05")
+
+	createReq := compute.CreateRequest{
+		Name: "my-multi-vnic-" + date,
+		MachineType: compute.IDOrName{
+			Name: helpers.StrPtr("BV1-1-40"),
+		},
+		Image: compute.IDOrName{
+			Name: helpers.StrPtr("cloud-ubuntu-24.04 LTS"),
+		},
+		// NetworkProfile replaces the singular Network field when you need more
+		// than one interface. Do not set both at the same time.
+		NetworkProfile: &compute.CreateParametersNetworkProfile{
+			Interfaces: []compute.CreateParametersNetworkInterfaceAttachment{
+				{
+					// Primary interface: new VNIC in a VPC, with a public IP.
+					Name:              helpers.StrPtr("nic-primary"),
+					Tag:               helpers.StrPtr("primary"),
+					Vpc:               &compute.IDOrName{ID: helpers.StrPtr("your-vpc-id")},
+					AssociatePublicIp: helpers.BoolPtr(true),
+					Subnets: &[]compute.CreateParametersNetworkInterfaceWithID{
+						{ID: "your-subnet-id"},
+					},
+					SecurityGroups: &[]compute.CreateParametersNetworkInterfaceWithID{
+						{ID: "your-security-group-id"},
+					},
+				},
+				{
+					// Secondary interface: private only, in a different VPC.
+					Name:              helpers.StrPtr("nic-secondary"),
+					Tag:               helpers.StrPtr("secondary"),
+					Vpc:               &compute.IDOrName{ID: helpers.StrPtr("another-vpc-id")},
+					AssociatePublicIp: helpers.BoolPtr(false),
+				},
+			},
+		},
+		SshKeyName: helpers.StrPtr("publio"),
+		UserData:   helpers.StrPtr(base64UserData),
+	}
+
+	id, err := computeClient.Instances().Create(context.Background(), createReq)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("Created instance with multiple VNICs, ID: %s\n", id)
+
+	return id
+}
+*/
+
+/*
 func ExampleGetInstance(id string) {
 	apiToken := os.Getenv("MGC_API_TOKEN")
 	if apiToken == "" {

--- a/compute/instances.go
+++ b/compute/instances.go
@@ -77,14 +77,15 @@ type Error struct {
 
 // CreateRequest represents the request to create a new instance.
 type CreateRequest struct {
-	AvailabilityZone *string                  `json:"availability_zone,omitempty"`
-	Image            IDOrName                 `json:"image"`
-	Labels           *[]string                `json:"labels,omitempty"`
-	MachineType      IDOrName                 `json:"machine_type"`
-	Name             string                   `json:"name"`
-	Network          *CreateParametersNetwork `json:"network,omitempty"`
-	SshKeyName       *string                  `json:"ssh_key_name,omitempty"`
-	UserData         *string                  `json:"user_data,omitempty"`
+	AvailabilityZone *string                         `json:"availability_zone,omitempty"`
+	Image            IDOrName                        `json:"image"`
+	Labels           *[]string                       `json:"labels,omitempty"`
+	MachineType      IDOrName                        `json:"machine_type"`
+	Name             string                          `json:"name"`
+	Network          *CreateParametersNetwork        `json:"network,omitempty"`
+	NetworkProfile   *CreateParametersNetworkProfile `json:"network_profile,omitempty"`
+	SshKeyName       *string                         `json:"ssh_key_name,omitempty"`
+	UserData         *string                         `json:"user_data,omitempty"`
 }
 
 // CreateParametersNetwork represents network configuration for instance creation.
@@ -98,11 +99,43 @@ type CreateParametersNetwork struct {
 type CreateParametersNetworkInterface struct {
 	ID             *string                                   `json:"id,omitempty"`
 	SecurityGroups *[]CreateParametersNetworkInterfaceWithID `json:"security_groups,omitempty"`
+	Subnets        *[]CreateParametersNetworkInterfaceWithID `json:"subnets,omitempty"`
 }
 
-// CreateParametersNetworkInterfaceWithID represents a security group item.
+// CreateParametersNetworkInterfaceWithID represents a resource referenced by its ID
+// (e.g. a security group or subnet).
 type CreateParametersNetworkInterfaceWithID struct {
 	ID string `json:"id"`
+}
+
+// CreateParametersNetworkProfile represents the configuration for attaching
+// multiple network interfaces (VNICs) to an instance at creation time.
+// It is mutually exclusive with the singular Network field.
+type CreateParametersNetworkProfile struct {
+	Interfaces []CreateParametersNetworkInterfaceAttachment `json:"interfaces,omitempty"`
+}
+
+// CreateParametersNetworkInterfaceAttachment represents a single network
+// interface (VNIC) to be attached to the instance during creation.
+type CreateParametersNetworkInterfaceAttachment struct {
+	// ID references an existing network interface by its ID. When provided,
+	// the interface is attached instead of a new one being created.
+	ID *CreateParametersNetworkInterfaceWithID `json:"id,omitempty"`
+	// Name is a human-readable name assigned to the network interface.
+	Name *string `json:"name,omitempty"`
+	// Vpc is the VPC where this interface will be attached. Defaults to the
+	// default VPC when omitted.
+	Vpc *IDOrName `json:"vpc,omitempty"`
+	// Subnets holds the subnet associated with this interface (maximum of 1).
+	Subnets *[]CreateParametersNetworkInterfaceWithID `json:"subnets,omitempty"`
+	// SecurityGroups holds the security group IDs applied to this interface.
+	SecurityGroups *[]CreateParametersNetworkInterfaceWithID `json:"security_groups,omitempty"`
+	// AssociatePublicIp indicates whether a public IP should be assigned to
+	// this interface. Defaults to false.
+	AssociatePublicIp *bool `json:"associate_public_ip,omitempty"`
+	// Tag is an optional device role tag exposed to the guest OS via metadata,
+	// ensuring reliable interface identification.
+	Tag *string `json:"tag,omitempty"`
 }
 
 // IDOrName represents a resource that can be identified by ID or name.
@@ -159,6 +192,7 @@ type NetworkInterface struct {
 	Primary              *bool              `json:"primary"`
 	AssociatedPublicIpv4 *string            `json:"associated_public_ipv4,omitempty"`
 	IpAddresses          IpAddressNewExpand `json:"ip_addresses"`
+	MacAddress           *string            `json:"mac_address,omitempty"`
 }
 
 // Network represents the network configuration of an instance.

--- a/compute/instances_test.go
+++ b/compute/instances_test.go
@@ -2,6 +2,7 @@ package compute
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -352,6 +353,91 @@ func TestInstanceService_Create(t *testing.T) {
 	}
 }
 
+func TestInstanceService_CreateWithMultipleVNICs(t *testing.T) {
+	t.Parallel()
+
+	associatePublicIp := true
+	primaryTag := "primary"
+	nicName := "nic-secondary"
+	req := CreateRequest{
+		Name:        "multi-vnic-vm",
+		MachineType: IDOrName{Name: strPtr("BV1-1-40")},
+		Image:       IDOrName{Name: strPtr("cloud-ubuntu-24.04 LTS")},
+		NetworkProfile: &CreateParametersNetworkProfile{
+			Interfaces: []CreateParametersNetworkInterfaceAttachment{
+				{
+					Name:              &nicName,
+					Vpc:               &IDOrName{ID: strPtr("vpc-1")},
+					AssociatePublicIp: &associatePublicIp,
+					Tag:               &primaryTag,
+					Subnets:           &[]CreateParametersNetworkInterfaceWithID{{ID: "subnet-1"}},
+					SecurityGroups:    &[]CreateParametersNetworkInterfaceWithID{{ID: "sg-1"}, {ID: "sg-2"}},
+				},
+				{
+					ID: &CreateParametersNetworkInterfaceWithID{ID: "existing-nic-1"},
+				},
+			},
+		},
+	}
+
+	var received map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&received); err != nil {
+			t.Fatalf("failed to decode request body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"id": "inst-multi"}`))
+	}))
+	defer server.Close()
+
+	client := testClient(server.URL)
+	gotID, err := client.Instances().Create(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Create() unexpected error: %v", err)
+	}
+	if gotID != "inst-multi" {
+		t.Errorf("Create() got = %v, want inst-multi", gotID)
+	}
+
+	// The singular network field must be absent when only network_profile is set.
+	if _, ok := received["network"]; ok {
+		t.Errorf("expected no 'network' field in payload, got one")
+	}
+
+	profile, ok := received["network_profile"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected 'network_profile' object in payload, got %T", received["network_profile"])
+	}
+	interfaces, ok := profile["interfaces"].([]any)
+	if !ok {
+		t.Fatalf("expected 'interfaces' array, got %T", profile["interfaces"])
+	}
+	if len(interfaces) != 2 {
+		t.Fatalf("expected 2 interfaces, got %d", len(interfaces))
+	}
+
+	first := interfaces[0].(map[string]any)
+	if first["name"] != nicName {
+		t.Errorf("first interface name = %v, want %v", first["name"], nicName)
+	}
+	if first["tag"] != primaryTag {
+		t.Errorf("first interface tag = %v, want %v", first["tag"], primaryTag)
+	}
+	if first["associate_public_ip"] != true {
+		t.Errorf("first interface associate_public_ip = %v, want true", first["associate_public_ip"])
+	}
+	if sgs, ok := first["security_groups"].([]any); !ok || len(sgs) != 2 {
+		t.Errorf("first interface security_groups = %v, want 2 items", first["security_groups"])
+	}
+
+	second := interfaces[1].(map[string]any)
+	id, ok := second["id"].(map[string]any)
+	if !ok || id["id"] != "existing-nic-1" {
+		t.Errorf("second interface id = %v, want {id: existing-nic-1}", second["id"])
+	}
+}
+
 func TestInstanceService_Get(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
@@ -361,6 +447,7 @@ func TestInstanceService_Get(t *testing.T) {
 		response   string
 		statusCode int
 		wantErr    bool
+		check      func(*testing.T, *Instance)
 	}{
 		{
 			name: "existing instance",
@@ -400,6 +487,51 @@ func TestInstanceService_Get(t *testing.T) {
 			wantErr:    false,
 		},
 		{
+			name:   "with multiple network interfaces",
+			id:     "inst1",
+			expand: []InstanceExpand{InstanceNetworkExpand},
+			response: `{
+				"id": "inst1",
+				"name": "test-vm",
+				"network": {
+					"vpc": {"id": "vpc1"},
+					"interfaces": [
+						{
+							"id": "nic1",
+							"name": "primary",
+							"primary": true,
+							"mac_address": "aa:bb:cc:dd:ee:01",
+							"ip_addresses": {"private_ipv4": "10.0.0.10"}
+						},
+						{
+							"id": "nic2",
+							"name": "secondary",
+							"primary": false,
+							"mac_address": "aa:bb:cc:dd:ee:02",
+							"ip_addresses": {"private_ipv4": "10.0.0.11"}
+						}
+					]
+				}
+			}`,
+			statusCode: http.StatusOK,
+			wantErr:    false,
+			check: func(t *testing.T, got *Instance) {
+				if got.Network == nil || got.Network.Interfaces == nil {
+					t.Fatal("expected network with interfaces, got nil")
+				}
+				ifaces := *got.Network.Interfaces
+				if len(ifaces) != 2 {
+					t.Fatalf("expected 2 interfaces, got %d", len(ifaces))
+				}
+				if ifaces[0].MacAddress == nil || *ifaces[0].MacAddress != "aa:bb:cc:dd:ee:01" {
+					t.Errorf("interface[0] mac_address = %v, want aa:bb:cc:dd:ee:01", ifaces[0].MacAddress)
+				}
+				if ifaces[1].MacAddress == nil || *ifaces[1].MacAddress != "aa:bb:cc:dd:ee:02" {
+					t.Errorf("interface[1] mac_address = %v, want aa:bb:cc:dd:ee:02", ifaces[1].MacAddress)
+				}
+			},
+		},
+		{
 			name:       "malformed response",
 			id:         "inst1",
 			response:   `{"id": "inst1", "name":}`,
@@ -436,6 +568,9 @@ func TestInstanceService_Get(t *testing.T) {
 				}
 				if got.ID != tt.id {
 					t.Errorf("Get() got ID = %v, want %v", got.ID, tt.id)
+				}
+				if tt.check != nil {
+					tt.check(t, got)
 				}
 			}
 		})


### PR DESCRIPTION
## What does this PR do?
Adiciona suporte à criação de instâncias de VM com **múltiplas interfaces de rede (VNICs)**, adaptando a SDK à nova versão do endpoint `POST /v1/instances`.

**Criação (`compute.CreateRequest`):**
- Novo campo `NetworkProfile` (`network_profile`), que aceita uma lista de interfaces (`Interfaces []CreateParametersNetworkInterfaceAttachment`). Cada interface suporta `id` (VNIC existente), `name`, `vpc`, `subnets`, `security_groups`, `associate_public_ip` e `tag`.
- Adicionado `Subnets` ao `CreateParametersNetworkInterface` (o schema `interface` singular passou a aceitar `subnets`).
- **Retrocompatível**: o campo `Network` (interface única) continua funcionando; `NetworkProfile` é opcional e mutuamente exclusivo com ele.

**Leitura (`GET /v1/instances/{id}`):**
- Adicionado o campo `MacAddress` (`mac_address`) a `NetworkInterface`. O array `network.interfaces` já era suportado, então múltiplas VNICs já eram lidas corretamente.

**Exemplo:**
- Novo `ExampleCreateInstanceWithMultipleVNICs` em `cmd/examples/compute/main.go`.

## How Has This Been Tested?
- `TestInstanceService_CreateWithMultipleVNICs`: valida a serialização do payload de `network_profile` (interfaces, tags, security groups, VNIC por ID existente) e garante que o campo `network` não é enviado quando apenas `network_profile` é usado.
- `TestInstanceService_Get` (caso `with multiple network interfaces`): valida a desserialização de múltiplas interfaces incluindo o novo campo `mac_address`.
- Suíte completa: `go build ./...`, `go vet ./compute/` e `go test ./compute/` passando.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
