### PR TITLE
feat: Add support for labels when creating nodepools

### DIFF
--- a/cmd/examples/kubernetes/main.go
+++ b/cmd/examples/kubernetes/main.go
@@ -87,6 +87,7 @@ func main() {
 	ExampleDeleteCluster(k8sClient, idComNodePool)
 
 	ExampleListVersions(k8sClient)
+	ExampleCreateNodepoolWithLabels(k8sClient, idComNodePool)
 }
 
 func deleteAllClusters(k8sClient *kubernetes.KubernetesClient) {
@@ -491,4 +492,27 @@ func ExampleListVersions(k8sClient *kubernetes.KubernetesClient) {
 
 		fmt.Println()
 	}
+}
+
+func ExampleCreateNodepoolWithLabels(k8sClient *kubernetes.KubernetesClient, clusterID string) {
+	ctx := context.Background()
+
+	labels := map[string]string{
+		"environment": "staging",
+		"team":        "devX",
+		"tier":        "backend",
+	}
+
+	poolReq := kubernetes.CreateNodePoolRequest{
+		Name:     "test-" + randomString(),
+		Flavor:   "BV2-2-40",
+		Replicas: 1,
+		Labels:   labels,
+	}
+
+	newPool, err := k8sClient.Nodepools().Create(ctx, clusterID, poolReq)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("Successfully created the nodepools with labels %+v ", newPool.Labels)
 }

--- a/cmd/examples/kubernetes/main.go
+++ b/cmd/examples/kubernetes/main.go
@@ -81,13 +81,13 @@ func main() {
 	ExampleNodePoolOperations(k8sClient, idComNodePool)
 	ExampleNodePoolOperationsWithEmptyTaints(k8sClient, idComNodePool)
 	ExampleNodePoolOperationsWithTaints(k8sClient, idComNodePool)
+	ExampleCreateNodepoolWithLabels(k8sClient, idComNodePool)
 
 	ExampleListFlavorsAndVersions(k8sClient)
 	ExampleDeleteCluster(k8sClient, idSemNodePool)
 	ExampleDeleteCluster(k8sClient, idComNodePool)
 
 	ExampleListVersions(k8sClient)
-	ExampleCreateNodepoolWithLabels(k8sClient, idComNodePool)
 }
 
 func deleteAllClusters(k8sClient *kubernetes.KubernetesClient) {

--- a/kubernetes/commons.go
+++ b/kubernetes/commons.go
@@ -86,6 +86,7 @@ type (
 		MaxPodsPerNode    *int                      `json:"max_pods_per_node,omitempty"`
 		AvailabilityZones *[]string                 `json:"availability_zones,omitempty"`
 		Network           *KubernetesNetworkRequest `json:"network,omitempty"`
+		Labels            map[string]string         `json:"labels,omitempty"`
 	}
 
 	KubernetesNetworkRequest struct {

--- a/kubernetes/nodepool_test.go
+++ b/kubernetes/nodepool_test.go
@@ -211,6 +211,79 @@ func TestNodePoolService_Create_WithCustomerChosenSubnets(t *testing.T) {
 	})
 }
 
+func TestNodePoolService_Create_WithLabels(t *testing.T) {
+	t.Parallel()
+
+	t.Run("customer informs labels and they are sent in the payload", func(t *testing.T) {
+		t.Parallel()
+		chosenLabels := map[string]string{
+			"environment": "staging",
+			"team":        "devX",
+			"tier":        "backend",
+		}
+
+		var sentPayload map[string]any
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			body, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(body, &sentPayload)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			w.Write([]byte(`{"id":"pool-new","name":"pool-new","replicas":2}`))
+		}))
+		defer server.Close()
+
+		_, err := testClient(server.URL).Nodepools().Create(context.Background(), "cluster-123", CreateNodePoolRequest{
+			Name:     "pool-new",
+			Flavor:   "BV4-8-40",
+			Replicas: 2,
+			Labels:   chosenLabels,
+		})
+		if err != nil {
+			t.Fatalf("Create() erro inesperado: %v", err)
+		}
+
+		rawLabels, present := sentPayload["labels"]
+		if !present {
+			t.Fatalf("esperava chave labels no payload, recebi: %v", sentPayload)
+		}
+		labels := rawLabels.(map[string]any)
+		if len(labels) != len(chosenLabels) {
+			t.Fatalf("esperava %d labels enviadas, recebi %d", len(chosenLabels), len(labels))
+		}
+		for k, v := range chosenLabels {
+			if labels[k] != v {
+				t.Errorf("label[%q] enviada = %v, esperava %s", k, labels[k], v)
+			}
+		}
+	})
+
+	t.Run("customer omits labels and the key is not present in the payload", func(t *testing.T) {
+		t.Parallel()
+		var sentPayload map[string]any
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			body, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(body, &sentPayload)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			w.Write([]byte(`{"id":"pool-new","name":"pool-new","replicas":2}`))
+		}))
+		defer server.Close()
+
+		_, err := testClient(server.URL).Nodepools().Create(context.Background(), "cluster-123", CreateNodePoolRequest{
+			Name:     "pool-new",
+			Flavor:   "BV4-8-40",
+			Replicas: 2,
+		})
+		if err != nil {
+			t.Fatalf("Create() erro inesperado: %v", err)
+		}
+
+		if _, present := sentPayload["labels"]; present {
+			t.Errorf("não esperava chave labels no payload quando cliente não informa labels, recebi: %v", sentPayload)
+		}
+	})
+}
+
 func TestNodePoolService_Delete(t *testing.T) {
 	tests := []struct {
 		name       string


### PR DESCRIPTION
## What does this PR do?
Novo campo `Labels`adicionado em CreateNodePoolRequest

exemplo: 
```
*kubernetes.KubernetesClient, clusterID string) {
	ctx := context.Background()

	labels := map[string]string{
		"environment": "staging",
		"team":        "devX",
		"tier":        "backend",
	}

	poolReq := kubernetes.CreateNodePoolRequest{
		Name:     "test-" + randomString(),
		Flavor:   "BV2-2-40",
		Replicas: 1,
		Labels:   labels,
	}
```


## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
