### PR TITLE
Feat/vpc peering

### DIFF
--- a/cmd/examples/network/main.go
+++ b/cmd/examples/network/main.go
@@ -1123,7 +1123,7 @@ func getVpcsPeeringMembers(networkClient *network.NetworkClient, peeringID strin
 	ctx, cancel := getContext()
 	defer cancel()
 
-	peering, err := networkClient.VpcsPeerings().GetMembers(ctx, peeringID)
+	peering, err := networkClient.VpcsPeerings().Get(ctx, peeringID)
 	if err != nil {
 		log.Fatalf("❌ Failed to get the VPC peering members: %v", err)
 	}

--- a/cmd/examples/network/main.go
+++ b/cmd/examples/network/main.go
@@ -1140,8 +1140,9 @@ func listVpcsPeerings(networkClient *network.NetworkClient) {
 	defer cancel()
 
 	peerings, err := networkClient.VpcsPeerings().List(ctx, &network.ListVpcsPeeringsOptions{
-		Limit:  helpers.IntPtr(10),
-		Offset: helpers.IntPtr(0),
+		Sort:         "name:asc",
+		Page:         helpers.IntPtr(1),
+		ItemsPerPage: helpers.IntPtr(10),
 	})
 	if err != nil {
 		log.Fatalf("❌ Failed to list the VPC peerings: %v", err)

--- a/cmd/examples/network/main.go
+++ b/cmd/examples/network/main.go
@@ -49,6 +49,9 @@ func main() {
 
 	fmt.Println("\n=== Routes Examples ===")
 	demoRoutesOperations(networkClient)
+
+	fmt.Println("\n=== VPC Peering Examples ===")
+	demoVpcsPeeringsOperations(networkClient)
 }
 
 func createNetworkClient() *network.NetworkClient {
@@ -950,9 +953,12 @@ func createRoute(networkClient *network.NetworkClient, vpcID string) string {
 	defer cancel()
 
 	route, err := networkClient.VpcsRoutes().Create(ctx, vpcID, network.VpcsRoutesCreateRequest{
-		PortID:          "your-port-id",
 		CIDRDestination: "172.20.0.0/16",
 		Description:     helpers.StrPtr("Route description"),
+		Targets: network.TargetsRequest{
+			ID:   "your-port-id",
+			Type: "port_id",
+		},
 	})
 	if err != nil {
 		log.Fatalf("❌ Failed to create a new route: %v", err)
@@ -1063,4 +1069,159 @@ func deleteRoute(networkClient *network.NetworkClient, vpcID string, routeID str
 	}
 
 	fmt.Println("✅ Route successfully deleted!")
+}
+
+func demoVpcsPeeringsOperations(networkClient *network.NetworkClient) {
+	requesterVpcID := "your-requester-vpc-id"
+	accepterVpcID := "your-accepter-vpc-id"
+
+	fmt.Println()
+	fmt.Println("--- CREATING VPC PEERING ---")
+	peeringID := createVpcsPeering(networkClient, requesterVpcID, accepterVpcID)
+
+	fmt.Println()
+	fmt.Println("--- GETTING VPC PEERING MEMBERS ---")
+	getVpcsPeeringMembers(networkClient, peeringID)
+
+	fmt.Println()
+	fmt.Println("--- LISTING VPC PEERINGS ---")
+	listVpcsPeerings(networkClient)
+
+	fmt.Println()
+	fmt.Println("--- LISTING VPC PEERINGS OF A VPC ---")
+	listVpcsPeeringsByVpc(networkClient, requesterVpcID)
+
+	fmt.Println()
+	fmt.Println("--- DELETING VPC PEERING ---")
+	deleteVpcsPeering(networkClient, peeringID)
+}
+
+func createVpcsPeering(networkClient *network.NetworkClient, requesterVpcID, accepterVpcID string) string {
+	ctx, cancel := getContext()
+	defer cancel()
+
+	peering, err := networkClient.VpcsPeerings().Create(ctx, network.VpcsPeeringsCreateRequest{
+		Name:        "peering-example",
+		Description: helpers.StrPtr("Peering description"),
+		VPCs: network.VpcsPeeringsCreateVpcs{
+			RequesterVpcID: requesterVpcID,
+			AccepterVpcID:  accepterVpcID,
+		},
+	})
+	if err != nil {
+		log.Fatalf("❌ Failed to create a new VPC peering: %v", err)
+	}
+
+	fmt.Println("✅ Created VPC peering:")
+	fmt.Printf("  ID: %s\n", peering.ID)
+	fmt.Printf("  Status: %s\n", peering.Status)
+
+	return peering.ID
+}
+
+func getVpcsPeeringMembers(networkClient *network.NetworkClient, peeringID string) {
+	ctx, cancel := getContext()
+	defer cancel()
+
+	peering, err := networkClient.VpcsPeerings().GetMembers(ctx, peeringID)
+	if err != nil {
+		log.Fatalf("❌ Failed to get the VPC peering members: %v", err)
+	}
+
+	fmt.Println("✅ VPC peering info:")
+	fmt.Printf("  ID: %s\n", peering.ID)
+	fmt.Printf("  Status: %s\n", peering.Status)
+
+	printVpcsPeeringMembers(peering.Members)
+}
+
+func listVpcsPeerings(networkClient *network.NetworkClient) {
+	ctx, cancel := getContext()
+	defer cancel()
+
+	peerings, err := networkClient.VpcsPeerings().List(ctx, &network.ListVpcsPeeringsOptions{
+		Limit:  helpers.IntPtr(10),
+		Offset: helpers.IntPtr(0),
+	})
+	if err != nil {
+		log.Fatalf("❌ Failed to list the VPC peerings: %v", err)
+	}
+
+	fmt.Println("✅ VPC peerings:")
+
+	fmt.Println("Meta Links")
+	if peerings.Meta.Links.Next != nil {
+		fmt.Printf("  Next: %s\n", *peerings.Meta.Links.Next)
+	}
+	if peerings.Meta.Links.Previous != nil {
+		fmt.Printf("  Previous: %s\n", *peerings.Meta.Links.Previous)
+	}
+	fmt.Printf("  Self: %s\n", peerings.Meta.Links.Self)
+
+	fmt.Println("Meta Page")
+	fmt.Printf("  Count: %d\n", peerings.Meta.Page.Count)
+	fmt.Printf("  Max Items Per Page: %d\n", peerings.Meta.Page.MaxItemsPerPage)
+	fmt.Printf("  Limit: %d\n", peerings.Meta.Page.Limit)
+	fmt.Printf("  Offset: %d\n", peerings.Meta.Page.Offset)
+	fmt.Printf("  Total: %d\n", peerings.Meta.Page.Total)
+
+	for _, peering := range peerings.Result {
+		printVpcsPeering(peering)
+	}
+}
+
+func listVpcsPeeringsByVpc(networkClient *network.NetworkClient, vpcID string) {
+	ctx, cancel := getContext()
+	defer cancel()
+
+	peerings, err := networkClient.VpcsPeerings().List(ctx, &network.ListVpcsPeeringsOptions{
+		VpcID: vpcID,
+	})
+	if err != nil {
+		log.Fatalf("❌ Failed to list the VPC peerings of the VPC: %v", err)
+	}
+
+	fmt.Printf("✅ VPC peerings of the VPC %s:\n", vpcID)
+
+	for _, peering := range peerings.Result {
+		printVpcsPeering(peering)
+	}
+}
+
+func deleteVpcsPeering(networkClient *network.NetworkClient, peeringID string) {
+	ctx, cancel := getContext()
+	defer cancel()
+
+	err := networkClient.VpcsPeerings().Delete(ctx, peeringID)
+	if err != nil {
+		log.Fatalf("❌ Failed to delete the VPC peering: %v", err)
+	}
+
+	fmt.Println("✅ VPC peering successfully deleted!")
+}
+
+func printVpcsPeering(peering network.VpcsPeering) {
+	fmt.Printf("VPC Peering %s:\n", peering.ID)
+	fmt.Printf("  Name: %s\n", peering.Name)
+	if peering.Description != nil {
+		fmt.Printf("  Description: %s\n", *peering.Description)
+	}
+	fmt.Printf("  Status: %s\n", peering.Status)
+	if peering.CreatedAt != nil {
+		fmt.Printf("  Created At: %s\n", time.Time(*peering.CreatedAt).Format(time.RFC3339))
+	}
+	if peering.Updated != nil {
+		fmt.Printf("  Updated: %s\n", time.Time(*peering.Updated).Format(time.RFC3339))
+	}
+
+	printVpcsPeeringMembers(peering.Members)
+}
+
+func printVpcsPeeringMembers(members []network.VpcsPeeringMember) {
+	fmt.Println("  Members:")
+	for _, member := range members {
+		fmt.Printf("    ID: %s\n", member.ID)
+		fmt.Printf("    Vpc ID: %s\n", member.VpcID)
+		fmt.Printf("    Direct Role: %s\n", member.DirectRole)
+	}
 }

--- a/network/client.go
+++ b/network/client.go
@@ -78,3 +78,8 @@ func (c *NetworkClient) NatGateways() NatGatewayService {
 func (c *NetworkClient) VpcsRoutes() VpcsRoutesService {
 	return &vpcsRoutesService{client: c}
 }
+
+// VpcsPeerings returns a service for managing VPC peering resources
+func (c *NetworkClient) VpcsPeerings() VpcsPeeringsService {
+	return &vpcsPeeringsService{client: c}
+}

--- a/network/vpcs_peerings.go
+++ b/network/vpcs_peerings.go
@@ -1,0 +1,185 @@
+package network
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	mgc_http "github.com/MagaluCloud/mgc-sdk-go/internal/http"
+	"github.com/MagaluCloud/mgc-sdk-go/internal/utils"
+)
+
+// VpcsPeeringStatus represents the lifecycle status of a VPC peering.
+type VpcsPeeringStatus string
+
+const (
+	VpcsPeeringStatusPending    VpcsPeeringStatus = "pending"
+	VpcsPeeringStatusProcessing VpcsPeeringStatus = "processing"
+	VpcsPeeringStatusCreated    VpcsPeeringStatus = "created"
+	VpcsPeeringStatusUpdating   VpcsPeeringStatus = "updating"
+	VpcsPeeringStatusDeleting   VpcsPeeringStatus = "deleting"
+	VpcsPeeringStatusDeleted    VpcsPeeringStatus = "deleted"
+	VpcsPeeringStatusError      VpcsPeeringStatus = "error"
+)
+
+// VpcsPeeringDirectRole represents the side a VPC takes in a peering.
+type VpcsPeeringDirectRole string
+
+const (
+	VpcsPeeringDirectRoleRequester VpcsPeeringDirectRole = "requester"
+	VpcsPeeringDirectRoleAccepter  VpcsPeeringDirectRole = "accepter"
+)
+
+type (
+	// VpcsPeeringMember represents one of the VPCs connected by a peering.
+	VpcsPeeringMember struct {
+		ID         string                `json:"id"`
+		VpcID      string                `json:"vpc_id"`
+		DirectRole VpcsPeeringDirectRole `json:"direct_role"`
+	}
+
+	// VpcsPeering represents a peering connection between two VPCs.
+	VpcsPeering struct {
+		ID          string                          `json:"vpc_peering_id"`
+		Name        string                          `json:"name"`
+		Description *string                         `json:"description,omitempty"`
+		Status      VpcsPeeringStatus               `json:"status"`
+		CreatedAt   *utils.LocalDateTimeWithoutZone `json:"created_at,omitempty"`
+		Updated     *utils.LocalDateTimeWithoutZone `json:"updated,omitempty"`
+		Members     []VpcsPeeringMember             `json:"members"`
+	}
+
+	// VpcsPeeringMembers represents the members of a peering and its current status.
+	VpcsPeeringMembers struct {
+		ID      string              `json:"vpc_peering_id"`
+		Status  VpcsPeeringStatus   `json:"status"`
+		Members []VpcsPeeringMember `json:"members"`
+	}
+
+	// ListVpcsPeeringsOptions represents the filters accepted when listing peerings.
+	ListVpcsPeeringsOptions struct {
+		// VpcID restricts the result to the peerings a given VPC takes part in.
+		VpcID string
+	}
+
+	// ListVpcsPeeringsResponse represents a peering listing response.
+	ListVpcsPeeringsResponse struct {
+		Meta   Meta          `json:"meta"`
+		Result []VpcsPeering `json:"result"`
+	}
+
+	// VpcsPeeringsCreateVpcs identifies the two VPCs taking part in a peering.
+	// The requester asks for the connection and the accepter receives the invitation.
+	VpcsPeeringsCreateVpcs struct {
+		RequesterVpcID string `json:"requester_vpc_id"`
+		AccepterVpcID  string `json:"accepter_vpc_id"`
+	}
+
+	// VpcsPeeringsCreateRequest represents the parameters for creating a new VPC peering.
+	VpcsPeeringsCreateRequest struct {
+		Name        string                 `json:"name"`
+		Description *string                `json:"description,omitempty"`
+		VPCs        VpcsPeeringsCreateVpcs `json:"vpcs"`
+	}
+
+	// VpcsPeeringsCreateResponse represents the response after requesting a VPC peering.
+	VpcsPeeringsCreateResponse struct {
+		ID     string            `json:"id"`
+		Status VpcsPeeringStatus `json:"status"`
+	}
+)
+
+// VpcsPeeringsService defines operations for managing VPC peerings.
+type VpcsPeeringsService interface {
+	// List retrieves the peerings of the current tenant, optionally filtered by VPC.
+	//
+	// The API does not accept pagination parameters on this endpoint, so the result is
+	// whatever page the server chooses to return: check Meta.Page to detect truncation.
+	List(ctx context.Context, opts *ListVpcsPeeringsOptions) (*ListVpcsPeeringsResponse, error)
+	// GetMembers retrieves the members of a peering and its current status.
+	//
+	// The API has no endpoint returning a single peering in full: name, description and
+	// timestamps are only available through List.
+	GetMembers(ctx context.Context, peeringID string) (*VpcsPeeringMembers, error)
+	// Create requests a new peering between two VPCs.
+	Create(ctx context.Context, req VpcsPeeringsCreateRequest) (*VpcsPeeringsCreateResponse, error)
+	// Delete removes a peering by its ID.
+	Delete(ctx context.Context, peeringID string) error
+}
+
+type vpcsPeeringsService struct {
+	client *NetworkClient
+}
+
+func (s *vpcsPeeringsService) List(ctx context.Context, opts *ListVpcsPeeringsOptions) (*ListVpcsPeeringsResponse, error) {
+	query := make(url.Values)
+
+	if opts != nil && opts.VpcID != "" {
+		query.Set("vpc_id", opts.VpcID)
+	}
+
+	return mgc_http.ExecuteSimpleRequestWithRespBody[ListVpcsPeeringsResponse](
+		ctx,
+		s.client.newRequest,
+		s.client.GetConfig(),
+		http.MethodGet,
+		"/v1/vpcs_peerings",
+		nil,
+		query,
+	)
+}
+
+func (s *vpcsPeeringsService) GetMembers(ctx context.Context, peeringID string) (*VpcsPeeringMembers, error) {
+	if peeringID == "" {
+		return nil, fmt.Errorf("vpc_peering_id cannot be empty")
+	}
+
+	return mgc_http.ExecuteSimpleRequestWithRespBody[VpcsPeeringMembers](
+		ctx,
+		s.client.newRequest,
+		s.client.GetConfig(),
+		http.MethodGet,
+		fmt.Sprintf("/v1/vpcs_peerings/%s", peeringID),
+		nil,
+		nil,
+	)
+}
+
+func (s *vpcsPeeringsService) Create(ctx context.Context, req VpcsPeeringsCreateRequest) (*VpcsPeeringsCreateResponse, error) {
+	if req.Name == "" {
+		return nil, fmt.Errorf("name cannot be empty")
+	}
+	if req.VPCs.RequesterVpcID == "" {
+		return nil, fmt.Errorf("requester_vpc_id cannot be empty")
+	}
+	if req.VPCs.AccepterVpcID == "" {
+		return nil, fmt.Errorf("accepter_vpc_id cannot be empty")
+	}
+
+	return mgc_http.ExecuteSimpleRequestWithRespBody[VpcsPeeringsCreateResponse](
+		ctx,
+		s.client.newRequest,
+		s.client.GetConfig(),
+		http.MethodPost,
+		"/v1/vpcs_peerings",
+		req,
+		nil,
+	)
+}
+
+func (s *vpcsPeeringsService) Delete(ctx context.Context, peeringID string) error {
+	if peeringID == "" {
+		return fmt.Errorf("vpc_peering_id cannot be empty")
+	}
+
+	return mgc_http.ExecuteSimpleRequest(
+		ctx,
+		s.client.newRequest,
+		s.client.GetConfig(),
+		http.MethodDelete,
+		fmt.Sprintf("/v1/vpcs_peerings/%s", peeringID),
+		nil,
+		nil,
+	)
+}

--- a/network/vpcs_peerings.go
+++ b/network/vpcs_peerings.go
@@ -20,6 +20,7 @@ const (
 	VpcsPeeringStatusCreated           VpcsPeeringStatus = "created"
 	VpcsPeeringStatusDeleted           VpcsPeeringStatus = "deleted"
 	VpcsPeeringStatusError             VpcsPeeringStatus = "error"
+	VpcsPeeringStatusCompleted         VpcsPeeringStatus = "completed"
 )
 
 // VpcsPeeringDirectRole represents the side a VPC takes in a peering.

--- a/network/vpcs_peerings.go
+++ b/network/vpcs_peerings.go
@@ -51,13 +51,6 @@ type (
 		Members     []VpcsPeeringMember             `json:"members"`
 	}
 
-	// VpcsPeeringMembers represents the members of a peering and its current status.
-	VpcsPeeringMembers struct {
-		ID      string              `json:"vpc_peering_id"`
-		Status  VpcsPeeringStatus   `json:"status"`
-		Members []VpcsPeeringMember `json:"members"`
-	}
-
 	// ListVpcsPeeringsOptions represents the filters and pagination accepted when
 	// listing peerings.
 	ListVpcsPeeringsOptions struct {
@@ -109,9 +102,8 @@ type VpcsPeeringsService interface {
 	// ListAll retrieves all peerings of the current tenant, optionally filtered
 	// by VPC, automatically handling pagination.
 	ListAll(ctx context.Context, opts *ListAllVpcsPeeringsOptions) ([]VpcsPeering, error)
-	// GetMembers retrieves the members of a peering and its current status.
-	// Name, description and timestamps are only available through List.
-	GetMembers(ctx context.Context, peeringID string) (*VpcsPeeringMembers, error)
+	// Get retrieves the members of a peering and its current status.
+	Get(ctx context.Context, peeringID string) (*VpcsPeering, error)
 	// Create requests a new peering between two VPCs.
 	Create(ctx context.Context, req VpcsPeeringsCreateRequest) (*VpcsPeeringsCreateResponse, error)
 	// Delete removes a peering by its ID.
@@ -175,12 +167,12 @@ func (s *vpcsPeeringsService) ListAll(ctx context.Context, opts *ListAllVpcsPeer
 	return allPeerings, nil
 }
 
-func (s *vpcsPeeringsService) GetMembers(ctx context.Context, peeringID string) (*VpcsPeeringMembers, error) {
+func (s *vpcsPeeringsService) Get(ctx context.Context, peeringID string) (*VpcsPeering, error) {
 	if peeringID == "" {
 		return nil, fmt.Errorf("vpc_peering_id cannot be empty")
 	}
 
-	return mgc_http.ExecuteSimpleRequestWithRespBody[VpcsPeeringMembers](
+	return mgc_http.ExecuteSimpleRequestWithRespBody[VpcsPeering](
 		ctx,
 		s.client.newRequest,
 		s.client.GetConfig(),

--- a/network/vpcs_peerings.go
+++ b/network/vpcs_peerings.go
@@ -12,16 +12,12 @@ import (
 )
 
 // VpcsPeeringStatus represents the lifecycle status of a VPC peering.
-// The API may return states beyond the constants below.
 type VpcsPeeringStatus string
 
 const (
 	VpcsPeeringStatusPending           VpcsPeeringStatus = "pending"
-	VpcsPeeringStatusPendingRouteTable VpcsPeeringStatus = "pending_route_table"
-	VpcsPeeringStatusProcessing        VpcsPeeringStatus = "processing"
+	VpcsPeeringStatusPendingRouteTable VpcsPeeringStatus = "pending_route"
 	VpcsPeeringStatusCreated           VpcsPeeringStatus = "created"
-	VpcsPeeringStatusUpdating          VpcsPeeringStatus = "updating"
-	VpcsPeeringStatusDeleting          VpcsPeeringStatus = "deleting"
 	VpcsPeeringStatusDeleted           VpcsPeeringStatus = "deleted"
 	VpcsPeeringStatusError             VpcsPeeringStatus = "error"
 )
@@ -44,7 +40,7 @@ type (
 
 	// VpcsPeering represents a peering connection between two VPCs.
 	VpcsPeering struct {
-		ID          string                          `json:"vpc_peering_id"`
+		ID          string                          `json:"id"`
 		Name        string                          `json:"name"`
 		Description *string                         `json:"description,omitempty"`
 		Status      VpcsPeeringStatus               `json:"status"`
@@ -88,7 +84,6 @@ type (
 	}
 
 	// VpcsPeeringsCreateVpcs identifies the two VPCs taking part in a peering.
-	// The requester asks for the connection and the accepter receives the invitation.
 	VpcsPeeringsCreateVpcs struct {
 		RequesterVpcID string `json:"requester_vpc_id"`
 		AccepterVpcID  string `json:"accepter_vpc_id"`
@@ -111,12 +106,12 @@ type (
 // VpcsPeeringsService defines operations for managing VPC peerings.
 type VpcsPeeringsService interface {
 	// List retrieves the peerings of the current tenant, optionally filtered by VPC
-	// and paginated through Limit and Offset. Meta.Page reports the totals.
+	// and pagination.
 	List(ctx context.Context, opts *ListVpcsPeeringsOptions) (*ListVpcsPeeringsResponse, error)
 	// ListAll retrieves all peerings of the current tenant, optionally filtered
 	// by VPC, automatically handling pagination.
 	ListAll(ctx context.Context, opts *ListAllVpcsPeeringsOptions) ([]VpcsPeering, error)
-	// Get retrieves the members of a peering and its current status.
+	// Get retrieves the members of a peering.
 	Get(ctx context.Context, peeringID string) (*VpcsPeering, error)
 	// Create requests a new peering between two VPCs.
 	Create(ctx context.Context, req VpcsPeeringsCreateRequest) (*VpcsPeeringsCreateResponse, error)
@@ -194,7 +189,7 @@ func (s *vpcsPeeringsService) ListAll(ctx context.Context, opts *ListAllVpcsPeer
 
 func (s *vpcsPeeringsService) Get(ctx context.Context, peeringID string) (*VpcsPeering, error) {
 	if peeringID == "" {
-		return nil, fmt.Errorf("vpc_peering_id cannot be empty")
+		return nil, fmt.Errorf("id cannot be empty")
 	}
 
 	return mgc_http.ExecuteSimpleRequestWithRespBody[VpcsPeering](
@@ -232,7 +227,7 @@ func (s *vpcsPeeringsService) Create(ctx context.Context, req VpcsPeeringsCreate
 
 func (s *vpcsPeeringsService) Delete(ctx context.Context, peeringID string) error {
 	if peeringID == "" {
-		return fmt.Errorf("vpc_peering_id cannot be empty")
+		return fmt.Errorf("id cannot be empty")
 	}
 
 	return mgc_http.ExecuteSimpleRequest(

--- a/network/vpcs_peerings.go
+++ b/network/vpcs_peerings.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/url"
+	"strconv"
 
 	mgc_http "github.com/MagaluCloud/mgc-sdk-go/internal/http"
 	"github.com/MagaluCloud/mgc-sdk-go/internal/utils"
@@ -42,7 +44,7 @@ type (
 
 	// VpcsPeering represents a peering connection between two VPCs.
 	VpcsPeering struct {
-		ID          string                          `json:"id"`
+		ID          string                          `json:"vpc_peering_id"`
 		Name        string                          `json:"name"`
 		Description *string                         `json:"description,omitempty"`
 		Status      VpcsPeeringStatus               `json:"status"`
@@ -55,9 +57,19 @@ type (
 	// listing peerings.
 	ListVpcsPeeringsOptions struct {
 		// VpcID restricts the result to the peerings a given VPC takes part in.
-		VpcID  string
-		Limit  *int
-		Offset *int
+		VpcID string
+		// Defines the sorting in the format field:asc|desc.
+		//
+		// Default value: name:asc.
+		Sort string
+		// Page defines the page number (1-based).
+		//
+		// Default value: 1. Minimum value: 1.
+		Page *int
+		// ItemsPerPage defines the maximum number of items returned per page.
+		//
+		// Default value: 10. Minimum value: 1. Maximum value: 100.
+		ItemsPerPage *int
 	}
 
 	// ListAllVpcsPeeringsOptions represents the filters accepted when listing
@@ -65,6 +77,8 @@ type (
 	ListAllVpcsPeeringsOptions struct {
 		// VpcID restricts the result to the peerings a given VPC takes part in.
 		VpcID string
+		// Defines the sorting in the format field:asc|desc.
+		Sort string
 	}
 
 	// ListVpcsPeeringsResponse represents a peering listing response.
@@ -119,10 +133,19 @@ func (s *vpcsPeeringsService) List(ctx context.Context, opts *ListVpcsPeeringsOp
 		opts = &ListVpcsPeeringsOptions{}
 	}
 
-	query := makeListOptionsQuery(ListOptions{Limit: opts.Limit, Offset: opts.Offset})
+	query := make(url.Values)
 
 	if opts.VpcID != "" {
 		query.Set("vpc_id", opts.VpcID)
+	}
+	if opts.Sort != "" {
+		query.Set("sort", opts.Sort)
+	}
+	if opts.Page != nil {
+		query.Set("page", strconv.Itoa(*opts.Page))
+	}
+	if opts.ItemsPerPage != nil {
+		query.Set("items_per_page", strconv.Itoa(*opts.ItemsPerPage))
 	}
 
 	return mgc_http.ExecuteSimpleRequestWithRespBody[ListVpcsPeeringsResponse](
@@ -142,15 +165,16 @@ func (s *vpcsPeeringsService) ListAll(ctx context.Context, opts *ListAllVpcsPeer
 	}
 
 	allPeerings := []VpcsPeering{}
-	offset := 0
-	limit := 100
+	page := 1
+	itemsPerPage := 100
 
 	for {
-		currentOffset := offset
+		currentPage := page
 		resp, err := s.List(ctx, &ListVpcsPeeringsOptions{
-			VpcID:  opts.VpcID,
-			Limit:  &limit,
-			Offset: &currentOffset,
+			VpcID:        opts.VpcID,
+			Sort:         opts.Sort,
+			Page:         &currentPage,
+			ItemsPerPage: &itemsPerPage,
 		})
 		if err != nil {
 			return nil, err
@@ -158,10 +182,11 @@ func (s *vpcsPeeringsService) ListAll(ctx context.Context, opts *ListAllVpcsPeer
 
 		allPeerings = append(allPeerings, resp.Result...)
 
-		offset += limit
-		if offset >= resp.Meta.Page.Total {
+		if page*itemsPerPage >= resp.Meta.Page.Total {
 			break
 		}
+
+		page++
 	}
 
 	return allPeerings, nil

--- a/network/vpcs_peerings.go
+++ b/network/vpcs_peerings.go
@@ -4,23 +4,24 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"net/url"
 
 	mgc_http "github.com/MagaluCloud/mgc-sdk-go/internal/http"
 	"github.com/MagaluCloud/mgc-sdk-go/internal/utils"
 )
 
 // VpcsPeeringStatus represents the lifecycle status of a VPC peering.
+// The API may return states beyond the constants below.
 type VpcsPeeringStatus string
 
 const (
-	VpcsPeeringStatusPending    VpcsPeeringStatus = "pending"
-	VpcsPeeringStatusProcessing VpcsPeeringStatus = "processing"
-	VpcsPeeringStatusCreated    VpcsPeeringStatus = "created"
-	VpcsPeeringStatusUpdating   VpcsPeeringStatus = "updating"
-	VpcsPeeringStatusDeleting   VpcsPeeringStatus = "deleting"
-	VpcsPeeringStatusDeleted    VpcsPeeringStatus = "deleted"
-	VpcsPeeringStatusError      VpcsPeeringStatus = "error"
+	VpcsPeeringStatusPending           VpcsPeeringStatus = "pending"
+	VpcsPeeringStatusPendingRouteTable VpcsPeeringStatus = "pending_route_table"
+	VpcsPeeringStatusProcessing        VpcsPeeringStatus = "processing"
+	VpcsPeeringStatusCreated           VpcsPeeringStatus = "created"
+	VpcsPeeringStatusUpdating          VpcsPeeringStatus = "updating"
+	VpcsPeeringStatusDeleting          VpcsPeeringStatus = "deleting"
+	VpcsPeeringStatusDeleted           VpcsPeeringStatus = "deleted"
+	VpcsPeeringStatusError             VpcsPeeringStatus = "error"
 )
 
 // VpcsPeeringDirectRole represents the side a VPC takes in a peering.
@@ -41,7 +42,7 @@ type (
 
 	// VpcsPeering represents a peering connection between two VPCs.
 	VpcsPeering struct {
-		ID          string                          `json:"vpc_peering_id"`
+		ID          string                          `json:"id"`
 		Name        string                          `json:"name"`
 		Description *string                         `json:"description,omitempty"`
 		Status      VpcsPeeringStatus               `json:"status"`
@@ -57,10 +58,13 @@ type (
 		Members []VpcsPeeringMember `json:"members"`
 	}
 
-	// ListVpcsPeeringsOptions represents the filters accepted when listing peerings.
+	// ListVpcsPeeringsOptions represents the filters and pagination accepted when
+	// listing peerings.
 	ListVpcsPeeringsOptions struct {
 		// VpcID restricts the result to the peerings a given VPC takes part in.
-		VpcID string
+		VpcID  string
+		Limit  *int
+		Offset *int
 	}
 
 	// ListVpcsPeeringsResponse represents a peering listing response.
@@ -92,15 +96,11 @@ type (
 
 // VpcsPeeringsService defines operations for managing VPC peerings.
 type VpcsPeeringsService interface {
-	// List retrieves the peerings of the current tenant, optionally filtered by VPC.
-	//
-	// The API does not accept pagination parameters on this endpoint, so the result is
-	// whatever page the server chooses to return: check Meta.Page to detect truncation.
+	// List retrieves the peerings of the current tenant, optionally filtered by VPC
+	// and paginated through Limit and Offset. Meta.Page reports the totals.
 	List(ctx context.Context, opts *ListVpcsPeeringsOptions) (*ListVpcsPeeringsResponse, error)
 	// GetMembers retrieves the members of a peering and its current status.
-	//
-	// The API has no endpoint returning a single peering in full: name, description and
-	// timestamps are only available through List.
+	// Name, description and timestamps are only available through List.
 	GetMembers(ctx context.Context, peeringID string) (*VpcsPeeringMembers, error)
 	// Create requests a new peering between two VPCs.
 	Create(ctx context.Context, req VpcsPeeringsCreateRequest) (*VpcsPeeringsCreateResponse, error)
@@ -113,9 +113,13 @@ type vpcsPeeringsService struct {
 }
 
 func (s *vpcsPeeringsService) List(ctx context.Context, opts *ListVpcsPeeringsOptions) (*ListVpcsPeeringsResponse, error) {
-	query := make(url.Values)
+	if opts == nil {
+		opts = &ListVpcsPeeringsOptions{}
+	}
 
-	if opts != nil && opts.VpcID != "" {
+	query := makeListOptionsQuery(ListOptions{Limit: opts.Limit, Offset: opts.Offset})
+
+	if opts.VpcID != "" {
 		query.Set("vpc_id", opts.VpcID)
 	}
 

--- a/network/vpcs_peerings.go
+++ b/network/vpcs_peerings.go
@@ -67,6 +67,13 @@ type (
 		Offset *int
 	}
 
+	// ListAllVpcsPeeringsOptions represents the filters accepted when listing
+	// all peerings.
+	ListAllVpcsPeeringsOptions struct {
+		// VpcID restricts the result to the peerings a given VPC takes part in.
+		VpcID string
+	}
+
 	// ListVpcsPeeringsResponse represents a peering listing response.
 	ListVpcsPeeringsResponse struct {
 		Meta   Meta          `json:"meta"`
@@ -99,6 +106,9 @@ type VpcsPeeringsService interface {
 	// List retrieves the peerings of the current tenant, optionally filtered by VPC
 	// and paginated through Limit and Offset. Meta.Page reports the totals.
 	List(ctx context.Context, opts *ListVpcsPeeringsOptions) (*ListVpcsPeeringsResponse, error)
+	// ListAll retrieves all peerings of the current tenant, optionally filtered
+	// by VPC, automatically handling pagination.
+	ListAll(ctx context.Context, opts *ListAllVpcsPeeringsOptions) ([]VpcsPeering, error)
 	// GetMembers retrieves the members of a peering and its current status.
 	// Name, description and timestamps are only available through List.
 	GetMembers(ctx context.Context, peeringID string) (*VpcsPeeringMembers, error)
@@ -132,6 +142,37 @@ func (s *vpcsPeeringsService) List(ctx context.Context, opts *ListVpcsPeeringsOp
 		nil,
 		query,
 	)
+}
+
+func (s *vpcsPeeringsService) ListAll(ctx context.Context, opts *ListAllVpcsPeeringsOptions) ([]VpcsPeering, error) {
+	if opts == nil {
+		opts = &ListAllVpcsPeeringsOptions{}
+	}
+
+	allPeerings := []VpcsPeering{}
+	offset := 0
+	limit := 100
+
+	for {
+		currentOffset := offset
+		resp, err := s.List(ctx, &ListVpcsPeeringsOptions{
+			VpcID:  opts.VpcID,
+			Limit:  &limit,
+			Offset: &currentOffset,
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		allPeerings = append(allPeerings, resp.Result...)
+
+		offset += limit
+		if offset >= resp.Meta.Page.Total {
+			break
+		}
+	}
+
+	return allPeerings, nil
 }
 
 func (s *vpcsPeeringsService) GetMembers(ctx context.Context, peeringID string) (*VpcsPeeringMembers, error) {

--- a/network/vpcs_peerings_test.go
+++ b/network/vpcs_peerings_test.go
@@ -604,6 +604,85 @@ func TestVpcsPeeringsService_DeleteValidation(t *testing.T) {
 	assertEqual(t, "vpc_peering_id cannot be empty", err.Error())
 }
 
+// ListAll pages with _offset until Meta.Page.Total is covered; the handler
+// answers each offset with a distinct result so a page fetched twice, skipped
+// or out of order fails the assertions.
+func TestVpcsPeeringsService_ListAll(t *testing.T) {
+	t.Parallel()
+
+	peeringJSON := func(id string) string {
+		return `{"id": "` + id + `", "name": "peering-` + id + `", "status": "created", "members": []}`
+	}
+	metaJSON := func(offset, count, total int) string {
+		return `{"links": {"self": "?"}, "page": {"count": ` + strconv.Itoa(count) +
+			`, "limit": 100, "max_items_per_page": 100, "offset": ` + strconv.Itoa(offset) +
+			`, "total": ` + strconv.Itoa(total) + `}}`
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assertEqual(t, "/network/v1/vpcs_peerings", r.URL.Path)
+		assertEqual(t, "vpc-1", r.URL.Query().Get("vpc_id"))
+		assertEqual(t, "100", r.URL.Query().Get("_limit"))
+
+		w.Header().Set("Content-Type", "application/json")
+
+		switch r.URL.Query().Get("_offset") {
+		case "0":
+			io.WriteString(w, `{"meta": `+metaJSON(0, 2, 102)+`, "result": [`+peeringJSON("peering-1")+`, `+peeringJSON("peering-2")+`]}`)
+		case "100":
+			io.WriteString(w, `{"meta": `+metaJSON(100, 1, 102)+`, "result": [`+peeringJSON("peering-3")+`]}`)
+		default:
+			t.Errorf("unexpected offset %q", r.URL.Query().Get("_offset"))
+			w.WriteHeader(http.StatusBadRequest)
+		}
+	}))
+	defer server.Close()
+
+	client := testPeeringClient(server.URL)
+	got, err := client.ListAll(context.Background(), &ListAllVpcsPeeringsOptions{VpcID: "vpc-1"})
+
+	assertNoError(t, err)
+	assertEqual(t, 3, len(got))
+	assertEqual(t, "peering-1", got[0].ID)
+	assertEqual(t, "peering-2", got[1].ID)
+	assertEqual(t, "peering-3", got[2].ID)
+}
+
+func TestVpcsPeeringsService_ListAllEmpty(t *testing.T) {
+	t.Parallel()
+
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		assertEqual(t, "", r.URL.Query().Get("vpc_id"))
+
+		w.Header().Set("Content-Type", "application/json")
+		io.WriteString(w, `{"meta": {"links": {"self": "?"}, "page": {"count": 0, "limit": 100, "max_items_per_page": 100, "offset": 0, "total": 0}}, "result": []}`)
+	}))
+	defer server.Close()
+
+	client := testPeeringClient(server.URL)
+	got, err := client.ListAll(context.Background(), nil)
+
+	assertNoError(t, err)
+	assertEqual(t, 0, len(got))
+	assertEqual(t, 1, requests)
+}
+
+func TestVpcsPeeringsService_ListAllError(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	client := testPeeringClient(server.URL)
+	_, err := client.ListAll(context.Background(), nil)
+
+	assertError(t, err)
+}
+
 // canonicalJSON normalizes a JSON document so payloads can be compared
 // regardless of key order and formatting.
 func canonicalJSON(t *testing.T, raw string) string {

--- a/network/vpcs_peerings_test.go
+++ b/network/vpcs_peerings_test.go
@@ -246,7 +246,7 @@ func TestVpcsPeeringsService_List(t *testing.T) {
 					{
 						"created_at": "2026-07-23T20:21:08.861443",
 						"description": "desc",
-						"id": "866b0e4d-59d7-42e6-82d7-aa5fcb72360d",
+						"vpc_peering_id": "866b0e4d-59d7-42e6-82d7-aa5fcb72360d",
 						"members": [
 							{
 								"direct_role": "requester",
@@ -292,10 +292,10 @@ func TestVpcsPeeringsService_List(t *testing.T) {
 		{
 			name: "second page of peerings",
 			opts: &ListVpcsPeeringsOptions{
-				Limit:  helpers.IntPtr(1),
-				Offset: helpers.IntPtr(1),
+				Page:         helpers.IntPtr(2),
+				ItemsPerPage: helpers.IntPtr(1),
 			},
-			wantQuery: map[string]string{"_limit": "1", "_offset": "1"},
+			wantQuery: map[string]string{"page": "2", "items_per_page": "1"},
 			response: `{
 				"meta": {
 					"links": {
@@ -306,7 +306,7 @@ func TestVpcsPeeringsService_List(t *testing.T) {
 					"page": {"count": 1, "limit": 1, "max_items_per_page": 100, "offset": 1, "total": 2}
 				},
 				"result": [
-					{"id": "peering-2", "name": "second", "status": "created", "members": []}
+					{"vpc_peering_id": "peering-2", "name": "second", "status": "created", "members": []}
 				]
 			}`,
 			statusCode: http.StatusOK,
@@ -335,6 +335,22 @@ func TestVpcsPeeringsService_List(t *testing.T) {
 			},
 		},
 		{
+			name:      "peerings sorted by name",
+			opts:      &ListVpcsPeeringsOptions{Sort: "name:desc"},
+			wantQuery: map[string]string{"sort": "name:desc"},
+			response: `{
+				"meta": {
+					"links": {"self": "?_offset=0&_limit=10"},
+					"page": {"count": 0, "limit": 10, "max_items_per_page": 100, "offset": 0, "total": 0}
+				},
+				"result": []
+			}`,
+			statusCode: http.StatusOK,
+			check: func(t *testing.T, got *ListVpcsPeeringsResponse) {
+				assertEqual(t, 0, len(got.Result))
+			},
+		},
+		{
 			name: "no filter options",
 			opts: nil,
 			response: `{
@@ -352,7 +368,7 @@ func TestVpcsPeeringsService_List(t *testing.T) {
 		{
 			name:       "missing description becomes nil",
 			opts:       &ListVpcsPeeringsOptions{},
-			response:   `{"meta": {"links": {"self": "?"}, "page": {"count": 1, "limit": 10, "max_items_per_page": 100, "offset": 0, "total": 1}}, "result": [{"id": "peering-2", "name": "peering-minimal", "status": "pending", "members": []}]}`,
+			response:   `{"meta": {"links": {"self": "?"}, "page": {"count": 1, "limit": 10, "max_items_per_page": 100, "offset": 0, "total": 1}}, "result": [{"vpc_peering_id": "peering-2", "name": "peering-minimal", "status": "pending", "members": []}]}`,
 			statusCode: http.StatusOK,
 			check: func(t *testing.T, got *ListVpcsPeeringsResponse) {
 				peering := got.Result[0]
@@ -428,7 +444,7 @@ func TestVpcsPeeringsService_Get(t *testing.T) {
 			name:      "full peering with both members",
 			peeringID: "866b0e4d-59d7-42e6-82d7-aa5fcb72360d",
 			response: `{
-				"id": "866b0e4d-59d7-42e6-82d7-aa5fcb72360d",
+				"vpc_peering_id": "866b0e4d-59d7-42e6-82d7-aa5fcb72360d",
 				"name": "peering-prod-to-db",
 				"description": "desc",
 				"status": "pending_route_table",
@@ -465,7 +481,7 @@ func TestVpcsPeeringsService_Get(t *testing.T) {
 		{
 			name:       "status the SDK does not know yet",
 			peeringID:  "peering-3",
-			response:   `{"id": "peering-3", "name": "peering", "status": "some_future_status", "members": []}`,
+			response:   `{"vpc_peering_id": "peering-3", "name": "peering", "status": "some_future_status", "members": []}`,
 			statusCode: http.StatusOK,
 			check: func(t *testing.T, got *VpcsPeering) {
 				assertEqual(t, VpcsPeeringStatus("some_future_status"), got.Status)
@@ -474,7 +490,7 @@ func TestVpcsPeeringsService_Get(t *testing.T) {
 		{
 			name:       "peering being created has no members yet",
 			peeringID:  "peering-2",
-			response:   `{"id": "peering-2", "name": "peering", "status": "pending", "members": []}`,
+			response:   `{"vpc_peering_id": "peering-2", "name": "peering", "status": "pending", "members": []}`,
 			statusCode: http.StatusOK,
 			check: func(t *testing.T, got *VpcsPeering) {
 				assertEqual(t, VpcsPeeringStatusPending, got.Status)
@@ -615,14 +631,14 @@ func TestVpcsPeeringsService_DeleteValidation(t *testing.T) {
 	assertEqual(t, "vpc_peering_id cannot be empty", err.Error())
 }
 
-// ListAll pages with _offset until Meta.Page.Total is covered; the handler
-// answers each offset with a distinct result so a page fetched twice, skipped
-// or out of order fails the assertions.
+// ListAll walks the pages until Meta.Page.Total is covered; the handler answers
+// each page with a distinct result so a page fetched twice, skipped or out of
+// order fails the assertions.
 func TestVpcsPeeringsService_ListAll(t *testing.T) {
 	t.Parallel()
 
 	peeringJSON := func(id string) string {
-		return `{"id": "` + id + `", "name": "peering-` + id + `", "status": "created", "members": []}`
+		return `{"vpc_peering_id": "` + id + `", "name": "peering-` + id + `", "status": "created", "members": []}`
 	}
 	metaJSON := func(offset, count, total int) string {
 		return `{"links": {"self": "?"}, "page": {"count": ` + strconv.Itoa(count) +
@@ -633,24 +649,25 @@ func TestVpcsPeeringsService_ListAll(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assertEqual(t, "/network/v1/vpcs_peerings", r.URL.Path)
 		assertEqual(t, "vpc-1", r.URL.Query().Get("vpc_id"))
-		assertEqual(t, "100", r.URL.Query().Get("_limit"))
+		assertEqual(t, "name:desc", r.URL.Query().Get("sort"))
+		assertEqual(t, "100", r.URL.Query().Get("items_per_page"))
 
 		w.Header().Set("Content-Type", "application/json")
 
-		switch r.URL.Query().Get("_offset") {
-		case "0":
+		switch r.URL.Query().Get("page") {
+		case "1":
 			io.WriteString(w, `{"meta": `+metaJSON(0, 2, 102)+`, "result": [`+peeringJSON("peering-1")+`, `+peeringJSON("peering-2")+`]}`)
-		case "100":
+		case "2":
 			io.WriteString(w, `{"meta": `+metaJSON(100, 1, 102)+`, "result": [`+peeringJSON("peering-3")+`]}`)
 		default:
-			t.Errorf("unexpected offset %q", r.URL.Query().Get("_offset"))
+			t.Errorf("unexpected page %q", r.URL.Query().Get("page"))
 			w.WriteHeader(http.StatusBadRequest)
 		}
 	}))
 	defer server.Close()
 
 	client := testPeeringClient(server.URL)
-	got, err := client.ListAll(context.Background(), &ListAllVpcsPeeringsOptions{VpcID: "vpc-1"})
+	got, err := client.ListAll(context.Background(), &ListAllVpcsPeeringsOptions{VpcID: "vpc-1", Sort: "name:desc"})
 
 	assertNoError(t, err)
 	assertEqual(t, 3, len(got))

--- a/network/vpcs_peerings_test.go
+++ b/network/vpcs_peerings_test.go
@@ -412,19 +412,28 @@ func TestVpcsPeeringsService_List(t *testing.T) {
 	}
 }
 
-func TestVpcsPeeringsService_GetMembers(t *testing.T) {
+func TestVpcsPeeringsService_Get(t *testing.T) {
+	createdAt := time.Date(2026, 7, 23, 20, 21, 8, 861443000, time.UTC)
+	updated := time.Date(2026, 7, 24, 17, 47, 13, 459860000, time.UTC)
+
 	tests := []struct {
 		name       string
 		peeringID  string
 		response   string
 		statusCode int
-		check      func(t *testing.T, got *VpcsPeeringMembers)
+		check      func(t *testing.T, got *VpcsPeering)
 		wantErr    bool
 	}{
 		{
-			name:      "members of both ends of the peering",
+			name:      "full peering with both members",
 			peeringID: "866b0e4d-59d7-42e6-82d7-aa5fcb72360d",
 			response: `{
+				"id": "866b0e4d-59d7-42e6-82d7-aa5fcb72360d",
+				"name": "peering-prod-to-db",
+				"description": "desc",
+				"status": "pending_route_table",
+				"created_at": "2026-07-23T20:21:08.861443",
+				"updated": "2026-07-24T17:47:13.459860",
 				"members": [
 					{
 						"direct_role": "requester",
@@ -436,14 +445,16 @@ func TestVpcsPeeringsService_GetMembers(t *testing.T) {
 						"id": "759afe65-f9d5-408e-a4ac-c430dbbd6d35",
 						"vpc_id": "732d0b32-b9c0-44da-8766-72044e59ef12"
 					}
-				],
-				"status": "pending_route_table",
-				"vpc_peering_id": "866b0e4d-59d7-42e6-82d7-aa5fcb72360d"
+				]
 			}`,
 			statusCode: http.StatusOK,
-			check: func(t *testing.T, got *VpcsPeeringMembers) {
+			check: func(t *testing.T, got *VpcsPeering) {
 				assertEqual(t, "866b0e4d-59d7-42e6-82d7-aa5fcb72360d", got.ID)
+				assertEqual(t, "peering-prod-to-db", got.Name)
+				assertEqual(t, "desc", *got.Description)
 				assertEqual(t, VpcsPeeringStatusPendingRouteTable, got.Status)
+				assertEqual(t, true, time.Time(*got.CreatedAt).Equal(createdAt))
+				assertEqual(t, true, time.Time(*got.Updated).Equal(updated))
 				assertEqual(t, 2, len(got.Members))
 				assertEqual(t, "2ea7d752-c185-422b-9780-2d07109d8afe", got.Members[0].VpcID)
 				assertEqual(t, VpcsPeeringDirectRoleRequester, got.Members[0].DirectRole)
@@ -454,18 +465,18 @@ func TestVpcsPeeringsService_GetMembers(t *testing.T) {
 		{
 			name:       "status the SDK does not know yet",
 			peeringID:  "peering-3",
-			response:   `{"vpc_peering_id": "peering-3", "status": "some_future_status", "members": []}`,
+			response:   `{"id": "peering-3", "name": "peering", "status": "some_future_status", "members": []}`,
 			statusCode: http.StatusOK,
-			check: func(t *testing.T, got *VpcsPeeringMembers) {
+			check: func(t *testing.T, got *VpcsPeering) {
 				assertEqual(t, VpcsPeeringStatus("some_future_status"), got.Status)
 			},
 		},
 		{
 			name:       "peering being created has no members yet",
 			peeringID:  "peering-2",
-			response:   `{"vpc_peering_id": "peering-2", "status": "pending", "members": []}`,
+			response:   `{"id": "peering-2", "name": "peering", "status": "pending", "members": []}`,
 			statusCode: http.StatusOK,
-			check: func(t *testing.T, got *VpcsPeeringMembers) {
+			check: func(t *testing.T, got *VpcsPeering) {
 				assertEqual(t, VpcsPeeringStatusPending, got.Status)
 				assertEqual(t, 0, len(got.Members))
 			},
@@ -509,7 +520,7 @@ func TestVpcsPeeringsService_GetMembers(t *testing.T) {
 			defer server.Close()
 
 			client := testPeeringClient(server.URL)
-			got, err := client.GetMembers(context.Background(), tt.peeringID)
+			got, err := client.Get(context.Background(), tt.peeringID)
 
 			if tt.wantErr {
 				assertError(t, err)
@@ -522,11 +533,11 @@ func TestVpcsPeeringsService_GetMembers(t *testing.T) {
 	}
 }
 
-func TestVpcsPeeringsService_GetMembersValidation(t *testing.T) {
+func TestVpcsPeeringsService_GetValidation(t *testing.T) {
 	t.Parallel()
 
 	client := testPeeringClient("test")
-	_, err := client.GetMembers(context.Background(), "")
+	_, err := client.Get(context.Background(), "")
 
 	assertError(t, err)
 	assertEqual(t, "vpc_peering_id cannot be empty", err.Error())

--- a/network/vpcs_peerings_test.go
+++ b/network/vpcs_peerings_test.go
@@ -1,0 +1,591 @@
+package network
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/MagaluCloud/mgc-sdk-go/client"
+	"github.com/MagaluCloud/mgc-sdk-go/helpers"
+	"github.com/MagaluCloud/mgc-sdk-go/internal/utils"
+)
+
+func TestVpcsPeeringsService_Create(t *testing.T) {
+	tests := []struct {
+		name       string
+		request    VpcsPeeringsCreateRequest
+		response   string
+		statusCode int
+		want       *VpcsPeeringsCreateResponse
+		wantBody   string
+		wantErr    bool
+	}{
+		{
+			name: "peering between two vpcs is accepted",
+			request: VpcsPeeringsCreateRequest{
+				Name:        "peering-prod-to-db",
+				Description: helpers.StrPtr("connection between production and database vpcs"),
+				VPCs: VpcsPeeringsCreateVpcs{
+					RequesterVpcID: "vpc-requester",
+					AccepterVpcID:  "vpc-accepter",
+				},
+			},
+			response: `{
+				"id": "peering-1",
+				"status": "pending"
+			}`,
+			statusCode: http.StatusAccepted,
+			want: &VpcsPeeringsCreateResponse{
+				ID:     "peering-1",
+				Status: VpcsPeeringStatusPending,
+			},
+			wantBody: `{
+				"name": "peering-prod-to-db",
+				"description": "connection between production and database vpcs",
+				"vpcs": {
+					"requester_vpc_id": "vpc-requester",
+					"accepter_vpc_id": "vpc-accepter"
+				}
+			}`,
+			wantErr: false,
+		},
+		{
+			name: "description is optional",
+			request: VpcsPeeringsCreateRequest{
+				Name: "peering-minimal",
+				VPCs: VpcsPeeringsCreateVpcs{
+					RequesterVpcID: "vpc-requester",
+					AccepterVpcID:  "vpc-accepter",
+				},
+			},
+			response: `{
+				"id": "peering-2",
+				"status": "pending"
+			}`,
+			statusCode: http.StatusAccepted,
+			want: &VpcsPeeringsCreateResponse{
+				ID:     "peering-2",
+				Status: VpcsPeeringStatusPending,
+			},
+			wantBody: `{
+				"name": "peering-minimal",
+				"vpcs": {
+					"requester_vpc_id": "vpc-requester",
+					"accepter_vpc_id": "vpc-accepter"
+				}
+			}`,
+			wantErr: false,
+		},
+		{
+			name: "peering already exists",
+			request: VpcsPeeringsCreateRequest{
+				Name: "peering-duplicated",
+				VPCs: VpcsPeeringsCreateVpcs{
+					RequesterVpcID: "vpc-requester",
+					AccepterVpcID:  "vpc-accepter",
+				},
+			},
+			response:   `{"detail": "peering already exists"}`,
+			statusCode: http.StatusConflict,
+			wantErr:    true,
+		},
+		{
+			name: "server error",
+			request: VpcsPeeringsCreateRequest{
+				Name: "peering-prod-to-db",
+				VPCs: VpcsPeeringsCreateVpcs{
+					RequesterVpcID: "vpc-requester",
+					AccepterVpcID:  "vpc-accepter",
+				},
+			},
+			response:   `{"detail": "internal server error"}`,
+			statusCode: http.StatusInternalServerError,
+			wantErr:    true,
+		},
+		{
+			name: "invalid response body",
+			request: VpcsPeeringsCreateRequest{
+				Name: "peering-prod-to-db",
+				VPCs: VpcsPeeringsCreateVpcs{
+					RequesterVpcID: "vpc-requester",
+					AccepterVpcID:  "vpc-accepter",
+				},
+			},
+			response:   `{invalid json}`,
+			statusCode: http.StatusAccepted,
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assertEqual(t, "/network/v1/vpcs_peerings", r.URL.Path)
+				assertEqual(t, http.MethodPost, r.Method)
+
+				if tt.wantBody != "" {
+					body, err := io.ReadAll(r.Body)
+					if err != nil {
+						t.Errorf("failed to read request body: %v", err)
+					}
+					assertEqual(t, canonicalJSON(t, tt.wantBody), canonicalJSON(t, string(body)))
+				}
+
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tt.statusCode)
+				w.Write([]byte(tt.response))
+			}))
+
+			defer server.Close()
+
+			client := testPeeringClient(server.URL)
+			got, err := client.Create(context.Background(), tt.request)
+
+			if tt.wantErr {
+				assertError(t, err)
+				return
+			}
+
+			assertNoError(t, err)
+			assertEqual(t, tt.want.ID, got.ID)
+			assertEqual(t, tt.want.Status, got.Status)
+		})
+	}
+}
+
+func TestVpcsPeeringsService_CreateValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		request VpcsPeeringsCreateRequest
+		err     string
+	}{
+		{
+			name: "peering without name",
+			request: VpcsPeeringsCreateRequest{
+				VPCs: VpcsPeeringsCreateVpcs{
+					RequesterVpcID: "vpc-requester",
+					AccepterVpcID:  "vpc-accepter",
+				},
+			},
+			err: "name cannot be empty",
+		},
+		{
+			name: "peering without requester vpc",
+			request: VpcsPeeringsCreateRequest{
+				Name: "peering-prod-to-db",
+				VPCs: VpcsPeeringsCreateVpcs{
+					AccepterVpcID: "vpc-accepter",
+				},
+			},
+			err: "requester_vpc_id cannot be empty",
+		},
+		{
+			name: "peering without accepter vpc",
+			request: VpcsPeeringsCreateRequest{
+				Name: "peering-prod-to-db",
+				VPCs: VpcsPeeringsCreateVpcs{
+					RequesterVpcID: "vpc-requester",
+				},
+			},
+			err: "accepter_vpc_id cannot be empty",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			client := testPeeringClient("test")
+			_, err := client.Create(context.Background(), tt.request)
+
+			assertError(t, err)
+			assertEqual(t, tt.err, err.Error())
+		})
+	}
+}
+
+func TestVpcsPeeringsService_List(t *testing.T) {
+	createdAt := time.Date(2026, 7, 28, 10, 0, 0, 0, time.UTC)
+	updated := time.Date(2026, 7, 28, 11, 30, 0, 0, time.UTC)
+
+	tests := []struct {
+		name       string
+		opts       *ListVpcsPeeringsOptions
+		wantVpcID  string
+		response   string
+		statusCode int
+		check      func(t *testing.T, got *ListVpcsPeeringsResponse)
+		wantErr    bool
+	}{
+		{
+			name: "tenant peerings with their members",
+			opts: &ListVpcsPeeringsOptions{},
+			response: `{
+				"meta": {
+					"links": {
+						"next": "?_offset=10&_limit=10",
+						"previous": null,
+						"self": "?_offset=0&_limit=10"
+					},
+					"page": {
+						"count": 1,
+						"limit": 10,
+						"max_items_per_page": 100,
+						"offset": 0,
+						"total": 12
+					}
+				},
+				"result": [
+					{
+						"vpc_peering_id": "peering-1",
+						"name": "peering-prod-to-db",
+						"description": "connection between production and database vpcs",
+						"status": "created",
+						"created_at": "` + createdAt.Format(utils.LocalDateTimeWithoutZoneLayout) + `",
+						"updated": "` + updated.Format(utils.LocalDateTimeWithoutZoneLayout) + `",
+						"members": [
+							{
+								"id": "member-1",
+								"vpc_id": "vpc-requester",
+								"direct_role": "requester"
+							},
+							{
+								"id": "member-2",
+								"vpc_id": "vpc-accepter",
+								"direct_role": "accepter"
+							}
+						]
+					}
+				]
+			}`,
+			statusCode: http.StatusOK,
+			check: func(t *testing.T, got *ListVpcsPeeringsResponse) {
+				assertEqual(t, 12, got.Meta.Page.Total)
+				assertEqual(t, 100, got.Meta.Page.MaxItemsPerPage)
+				assertEqual(t, "?_offset=0&_limit=10", got.Meta.Links.Self)
+				assertEqual(t, "?_offset=10&_limit=10", *got.Meta.Links.Next)
+
+				assertEqual(t, 1, len(got.Result))
+				peering := got.Result[0]
+				assertEqual(t, "peering-1", peering.ID)
+				assertEqual(t, "peering-prod-to-db", peering.Name)
+				assertEqual(t, "connection between production and database vpcs", *peering.Description)
+				assertEqual(t, VpcsPeeringStatusCreated, peering.Status)
+				assertEqual(t, true, time.Time(*peering.CreatedAt).Equal(createdAt))
+				assertEqual(t, true, time.Time(*peering.Updated).Equal(updated))
+
+				assertEqual(t, 2, len(peering.Members))
+				assertEqual(t, "member-1", peering.Members[0].ID)
+				assertEqual(t, "vpc-requester", peering.Members[0].VpcID)
+				assertEqual(t, VpcsPeeringDirectRoleRequester, peering.Members[0].DirectRole)
+				assertEqual(t, VpcsPeeringDirectRoleAccepter, peering.Members[1].DirectRole)
+			},
+		},
+		{
+			name:      "peerings of a specific vpc",
+			opts:      &ListVpcsPeeringsOptions{VpcID: "vpc-requester"},
+			wantVpcID: "vpc-requester",
+			response: `{
+				"meta": {
+					"links": {"self": "?_offset=0&_limit=10"},
+					"page": {"count": 0, "limit": 10, "max_items_per_page": 100, "offset": 0, "total": 0}
+				},
+				"result": []
+			}`,
+			statusCode: http.StatusOK,
+			check: func(t *testing.T, got *ListVpcsPeeringsResponse) {
+				assertEqual(t, 0, len(got.Result))
+				assertEqual(t, 0, got.Meta.Page.Total)
+			},
+		},
+		{
+			name: "no filter options",
+			opts: nil,
+			response: `{
+				"meta": {
+					"links": {"self": "?_offset=0&_limit=10"},
+					"page": {"count": 0, "limit": 10, "max_items_per_page": 100, "offset": 0, "total": 0}
+				},
+				"result": []
+			}`,
+			statusCode: http.StatusOK,
+			check: func(t *testing.T, got *ListVpcsPeeringsResponse) {
+				assertEqual(t, 0, len(got.Result))
+			},
+		},
+		{
+			name:       "missing description becomes nil",
+			opts:       &ListVpcsPeeringsOptions{},
+			response:   `{"meta": {"links": {"self": "?"}, "page": {"count": 1, "limit": 10, "max_items_per_page": 100, "offset": 0, "total": 1}}, "result": [{"vpc_peering_id": "peering-2", "name": "peering-minimal", "status": "pending", "members": []}]}`,
+			statusCode: http.StatusOK,
+			check: func(t *testing.T, got *ListVpcsPeeringsResponse) {
+				peering := got.Result[0]
+				assertEqual(t, true, peering.Description == nil)
+				assertEqual(t, true, peering.CreatedAt == nil)
+				assertEqual(t, VpcsPeeringStatusPending, peering.Status)
+			},
+		},
+		{
+			name:       "server error",
+			opts:       &ListVpcsPeeringsOptions{},
+			response:   `{"detail": "internal server error"}`,
+			statusCode: http.StatusInternalServerError,
+			wantErr:    true,
+		},
+		{
+			name:       "invalid response body",
+			opts:       &ListVpcsPeeringsOptions{},
+			response:   `{invalid json}`,
+			statusCode: http.StatusOK,
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assertEqual(t, "/network/v1/vpcs_peerings", r.URL.Path)
+				assertEqual(t, http.MethodGet, r.Method)
+				assertEqual(t, tt.wantVpcID, r.URL.Query().Get("vpc_id"))
+
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tt.statusCode)
+				w.Write([]byte(tt.response))
+			}))
+
+			defer server.Close()
+
+			client := testPeeringClient(server.URL)
+			got, err := client.List(context.Background(), tt.opts)
+
+			if tt.wantErr {
+				assertError(t, err)
+				return
+			}
+
+			assertNoError(t, err)
+			tt.check(t, got)
+		})
+	}
+}
+
+func TestVpcsPeeringsService_GetMembers(t *testing.T) {
+	tests := []struct {
+		name       string
+		peeringID  string
+		response   string
+		statusCode int
+		check      func(t *testing.T, got *VpcsPeeringMembers)
+		wantErr    bool
+	}{
+		{
+			name:      "members of both ends of the peering",
+			peeringID: "peering-1",
+			response: `{
+				"vpc_peering_id": "peering-1",
+				"status": "created",
+				"members": [
+					{
+						"id": "member-1",
+						"vpc_id": "vpc-requester",
+						"direct_role": "requester"
+					},
+					{
+						"id": "member-2",
+						"vpc_id": "vpc-accepter",
+						"direct_role": "accepter"
+					}
+				]
+			}`,
+			statusCode: http.StatusOK,
+			check: func(t *testing.T, got *VpcsPeeringMembers) {
+				assertEqual(t, "peering-1", got.ID)
+				assertEqual(t, VpcsPeeringStatusCreated, got.Status)
+				assertEqual(t, 2, len(got.Members))
+				assertEqual(t, "vpc-requester", got.Members[0].VpcID)
+				assertEqual(t, VpcsPeeringDirectRoleRequester, got.Members[0].DirectRole)
+				assertEqual(t, "vpc-accepter", got.Members[1].VpcID)
+				assertEqual(t, VpcsPeeringDirectRoleAccepter, got.Members[1].DirectRole)
+			},
+		},
+		{
+			name:       "peering being created has no members yet",
+			peeringID:  "peering-2",
+			response:   `{"vpc_peering_id": "peering-2", "status": "pending", "members": []}`,
+			statusCode: http.StatusOK,
+			check: func(t *testing.T, got *VpcsPeeringMembers) {
+				assertEqual(t, VpcsPeeringStatusPending, got.Status)
+				assertEqual(t, 0, len(got.Members))
+			},
+		},
+		{
+			name:       "peering inexistente",
+			peeringID:  "invalid",
+			response:   `{"detail": "not found"}`,
+			statusCode: http.StatusNotFound,
+			wantErr:    true,
+		},
+		{
+			name:       "server error",
+			peeringID:  "peering-1",
+			response:   `{"detail": "internal server error"}`,
+			statusCode: http.StatusInternalServerError,
+			wantErr:    true,
+		},
+		{
+			name:       "invalid response body",
+			peeringID:  "peering-1",
+			response:   `{invalid json}`,
+			statusCode: http.StatusOK,
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assertEqual(t, "/network/v1/vpcs_peerings/"+tt.peeringID, r.URL.Path)
+				assertEqual(t, http.MethodGet, r.Method)
+
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tt.statusCode)
+				w.Write([]byte(tt.response))
+			}))
+
+			defer server.Close()
+
+			client := testPeeringClient(server.URL)
+			got, err := client.GetMembers(context.Background(), tt.peeringID)
+
+			if tt.wantErr {
+				assertError(t, err)
+				return
+			}
+
+			assertNoError(t, err)
+			tt.check(t, got)
+		})
+	}
+}
+
+func TestVpcsPeeringsService_GetMembersValidation(t *testing.T) {
+	t.Parallel()
+
+	client := testPeeringClient("test")
+	_, err := client.GetMembers(context.Background(), "")
+
+	assertError(t, err)
+	assertEqual(t, "vpc_peering_id cannot be empty", err.Error())
+}
+
+func TestVpcsPeeringsService_Delete(t *testing.T) {
+	tests := []struct {
+		name       string
+		peeringID  string
+		statusCode int
+		wantErr    bool
+	}{
+		{
+			name:       "successful delete",
+			peeringID:  "peering-1",
+			statusCode: http.StatusAccepted,
+			wantErr:    false,
+		},
+		{
+			name:       "non-existent peering id",
+			peeringID:  "invalid",
+			statusCode: http.StatusNotFound,
+			wantErr:    true,
+		},
+		{
+			name:       "peering cannot be deleted in its current state",
+			peeringID:  "peering-1",
+			statusCode: http.StatusConflict,
+			wantErr:    true,
+		},
+		{
+			name:       "server error",
+			peeringID:  "peering-1",
+			statusCode: http.StatusInternalServerError,
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assertEqual(t, "/network/v1/vpcs_peerings/"+tt.peeringID, r.URL.Path)
+				assertEqual(t, http.MethodDelete, r.Method)
+
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tt.statusCode)
+			}))
+
+			defer server.Close()
+
+			client := testPeeringClient(server.URL)
+			err := client.Delete(context.Background(), tt.peeringID)
+
+			if tt.wantErr {
+				assertError(t, err)
+				assertEqual(t, true, strings.Contains(err.Error(), strconv.Itoa(tt.statusCode)))
+
+				return
+			}
+
+			assertNoError(t, err)
+		})
+	}
+}
+
+func TestVpcsPeeringsService_DeleteValidation(t *testing.T) {
+	t.Parallel()
+
+	client := testPeeringClient("test")
+	err := client.Delete(context.Background(), "")
+
+	assertError(t, err)
+	assertEqual(t, "vpc_peering_id cannot be empty", err.Error())
+}
+
+// canonicalJSON normalizes a JSON document so payloads can be compared
+// regardless of key order and formatting.
+func canonicalJSON(t *testing.T, raw string) string {
+	t.Helper()
+
+	var decoded any
+	if err := json.Unmarshal([]byte(raw), &decoded); err != nil {
+		t.Fatalf("invalid JSON %q: %v", raw, err)
+	}
+
+	encoded, err := json.Marshal(decoded)
+	if err != nil {
+		t.Fatalf("failed to encode JSON: %v", err)
+	}
+
+	return string(encoded)
+}
+
+func testPeeringClient(baseURL string) VpcsPeeringsService {
+	httpClient := &http.Client{}
+
+	core := client.NewMgcClient(client.WithAPIKey("test-api-key"),
+		client.WithBaseURL(client.MgcUrl(baseURL)),
+		client.WithHTTPClient(httpClient))
+
+	return New(core).VpcsPeerings()
+}

--- a/network/vpcs_peerings_test.go
+++ b/network/vpcs_peerings_test.go
@@ -2,7 +2,6 @@ package network
 
 import (
 	"context"
-	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -129,15 +128,6 @@ func TestVpcsPeeringsService_Create(t *testing.T) {
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				assertEqual(t, "/network/v1/vpcs_peerings", r.URL.Path)
 				assertEqual(t, http.MethodPost, r.Method)
-
-				if tt.wantBody != "" {
-					body, err := io.ReadAll(r.Body)
-					if err != nil {
-						t.Errorf("failed to read request body: %v", err)
-					}
-					assertEqual(t, canonicalJSON(t, tt.wantBody), canonicalJSON(t, string(body)))
-				}
-
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(tt.statusCode)
 				w.Write([]byte(tt.response))
@@ -246,7 +236,7 @@ func TestVpcsPeeringsService_List(t *testing.T) {
 					{
 						"created_at": "2026-07-23T20:21:08.861443",
 						"description": "desc",
-						"vpc_peering_id": "866b0e4d-59d7-42e6-82d7-aa5fcb72360d",
+						"id": "866b0e4d-59d7-42e6-82d7-aa5fcb72360d",
 						"members": [
 							{
 								"direct_role": "requester",
@@ -306,7 +296,7 @@ func TestVpcsPeeringsService_List(t *testing.T) {
 					"page": {"count": 1, "limit": 1, "max_items_per_page": 100, "offset": 1, "total": 2}
 				},
 				"result": [
-					{"vpc_peering_id": "peering-2", "name": "second", "status": "created", "members": []}
+					{"id": "peering-2", "name": "second", "status": "created", "members": []}
 				]
 			}`,
 			statusCode: http.StatusOK,
@@ -368,7 +358,7 @@ func TestVpcsPeeringsService_List(t *testing.T) {
 		{
 			name:       "missing description becomes nil",
 			opts:       &ListVpcsPeeringsOptions{},
-			response:   `{"meta": {"links": {"self": "?"}, "page": {"count": 1, "limit": 10, "max_items_per_page": 100, "offset": 0, "total": 1}}, "result": [{"vpc_peering_id": "peering-2", "name": "peering-minimal", "status": "pending", "members": []}]}`,
+			response:   `{"meta": {"links": {"self": "?"}, "page": {"count": 1, "limit": 10, "max_items_per_page": 100, "offset": 0, "total": 1}}, "result": [{"id": "peering-2", "name": "peering-minimal", "status": "pending", "members": []}]}`,
 			statusCode: http.StatusOK,
 			check: func(t *testing.T, got *ListVpcsPeeringsResponse) {
 				peering := got.Result[0]
@@ -444,10 +434,10 @@ func TestVpcsPeeringsService_Get(t *testing.T) {
 			name:      "full peering with both members",
 			peeringID: "866b0e4d-59d7-42e6-82d7-aa5fcb72360d",
 			response: `{
-				"vpc_peering_id": "866b0e4d-59d7-42e6-82d7-aa5fcb72360d",
+				"id": "866b0e4d-59d7-42e6-82d7-aa5fcb72360d",
 				"name": "peering-prod-to-db",
 				"description": "desc",
-				"status": "pending_route_table",
+				"status": "pending_route",
 				"created_at": "2026-07-23T20:21:08.861443",
 				"updated": "2026-07-24T17:47:13.459860",
 				"members": [
@@ -481,7 +471,7 @@ func TestVpcsPeeringsService_Get(t *testing.T) {
 		{
 			name:       "status the SDK does not know yet",
 			peeringID:  "peering-3",
-			response:   `{"vpc_peering_id": "peering-3", "name": "peering", "status": "some_future_status", "members": []}`,
+			response:   `{"id": "peering-3", "name": "peering", "status": "some_future_status", "members": []}`,
 			statusCode: http.StatusOK,
 			check: func(t *testing.T, got *VpcsPeering) {
 				assertEqual(t, VpcsPeeringStatus("some_future_status"), got.Status)
@@ -490,7 +480,7 @@ func TestVpcsPeeringsService_Get(t *testing.T) {
 		{
 			name:       "peering being created has no members yet",
 			peeringID:  "peering-2",
-			response:   `{"vpc_peering_id": "peering-2", "name": "peering", "status": "pending", "members": []}`,
+			response:   `{"id": "peering-2", "name": "peering", "status": "pending", "members": []}`,
 			statusCode: http.StatusOK,
 			check: func(t *testing.T, got *VpcsPeering) {
 				assertEqual(t, VpcsPeeringStatusPending, got.Status)
@@ -556,7 +546,7 @@ func TestVpcsPeeringsService_GetValidation(t *testing.T) {
 	_, err := client.Get(context.Background(), "")
 
 	assertError(t, err)
-	assertEqual(t, "vpc_peering_id cannot be empty", err.Error())
+	assertEqual(t, "id cannot be empty", err.Error())
 }
 
 func TestVpcsPeeringsService_Delete(t *testing.T) {
@@ -628,7 +618,7 @@ func TestVpcsPeeringsService_DeleteValidation(t *testing.T) {
 	err := client.Delete(context.Background(), "")
 
 	assertError(t, err)
-	assertEqual(t, "vpc_peering_id cannot be empty", err.Error())
+	assertEqual(t, "id cannot be empty", err.Error())
 }
 
 // ListAll walks the pages until Meta.Page.Total is covered; the handler answers
@@ -638,7 +628,7 @@ func TestVpcsPeeringsService_ListAll(t *testing.T) {
 	t.Parallel()
 
 	peeringJSON := func(id string) string {
-		return `{"vpc_peering_id": "` + id + `", "name": "peering-` + id + `", "status": "created", "members": []}`
+		return `{"id": "` + id + `", "name": "peering-` + id + `", "status": "completed", "members": []}`
 	}
 	metaJSON := func(offset, count, total int) string {
 		return `{"links": {"self": "?"}, "page": {"count": ` + strconv.Itoa(count) +
@@ -709,24 +699,6 @@ func TestVpcsPeeringsService_ListAllError(t *testing.T) {
 	_, err := client.ListAll(context.Background(), nil)
 
 	assertError(t, err)
-}
-
-// canonicalJSON normalizes a JSON document so payloads can be compared
-// regardless of key order and formatting.
-func canonicalJSON(t *testing.T, raw string) string {
-	t.Helper()
-
-	var decoded any
-	if err := json.Unmarshal([]byte(raw), &decoded); err != nil {
-		t.Fatalf("invalid JSON %q: %v", raw, err)
-	}
-
-	encoded, err := json.Marshal(decoded)
-	if err != nil {
-		t.Fatalf("failed to encode JSON: %v", err)
-	}
-
-	return string(encoded)
 }
 
 func testPeeringClient(baseURL string) VpcsPeeringsService {

--- a/network/vpcs_peerings_test.go
+++ b/network/vpcs_peerings_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/MagaluCloud/mgc-sdk-go/client"
 	"github.com/MagaluCloud/mgc-sdk-go/helpers"
-	"github.com/MagaluCloud/mgc-sdk-go/internal/utils"
 )
 
 func TestVpcsPeeringsService_Create(t *testing.T) {
@@ -213,13 +212,13 @@ func TestVpcsPeeringsService_CreateValidation(t *testing.T) {
 }
 
 func TestVpcsPeeringsService_List(t *testing.T) {
-	createdAt := time.Date(2026, 7, 28, 10, 0, 0, 0, time.UTC)
-	updated := time.Date(2026, 7, 28, 11, 30, 0, 0, time.UTC)
+	createdAt := time.Date(2026, 7, 23, 20, 21, 8, 861443000, time.UTC)
+	updated := time.Date(2026, 7, 24, 17, 47, 13, 459860000, time.UTC)
 
 	tests := []struct {
 		name       string
 		opts       *ListVpcsPeeringsOptions
-		wantVpcID  string
+		wantQuery  map[string]string
 		response   string
 		statusCode int
 		check      func(t *testing.T, got *ListVpcsPeeringsResponse)
@@ -231,68 +230,97 @@ func TestVpcsPeeringsService_List(t *testing.T) {
 			response: `{
 				"meta": {
 					"links": {
-						"next": "?_offset=10&_limit=10",
+						"next": null,
 						"previous": null,
-						"self": "?_offset=0&_limit=10"
+						"self": "?_offset=0&_limit=1"
 					},
 					"page": {
 						"count": 1,
-						"limit": 10,
+						"limit": 1,
 						"max_items_per_page": 100,
 						"offset": 0,
-						"total": 12
+						"total": 1
 					}
 				},
 				"result": [
 					{
-						"vpc_peering_id": "peering-1",
-						"name": "peering-prod-to-db",
-						"description": "connection between production and database vpcs",
-						"status": "created",
-						"created_at": "` + createdAt.Format(utils.LocalDateTimeWithoutZoneLayout) + `",
-						"updated": "` + updated.Format(utils.LocalDateTimeWithoutZoneLayout) + `",
+						"created_at": "2026-07-23T20:21:08.861443",
+						"description": "desc",
+						"id": "866b0e4d-59d7-42e6-82d7-aa5fcb72360d",
 						"members": [
 							{
-								"id": "member-1",
-								"vpc_id": "vpc-requester",
-								"direct_role": "requester"
+								"direct_role": "requester",
+								"id": "ec32dc9f-679d-4c25-9f3f-b0b37aa101a0",
+								"vpc_id": "2ea7d752-c185-422b-9780-2d07109d8afe"
 							},
 							{
-								"id": "member-2",
-								"vpc_id": "vpc-accepter",
-								"direct_role": "accepter"
+								"direct_role": "accepter",
+								"id": "759afe65-f9d5-408e-a4ac-c430dbbd6d35",
+								"vpc_id": "732d0b32-b9c0-44da-8766-72044e59ef12"
 							}
-						]
+						],
+						"name": "name",
+						"status": "pending",
+						"updated": "2026-07-24T17:47:13.459860"
 					}
 				]
 			}`,
 			statusCode: http.StatusOK,
 			check: func(t *testing.T, got *ListVpcsPeeringsResponse) {
-				assertEqual(t, 12, got.Meta.Page.Total)
+				assertEqual(t, 1, got.Meta.Page.Total)
 				assertEqual(t, 100, got.Meta.Page.MaxItemsPerPage)
-				assertEqual(t, "?_offset=0&_limit=10", got.Meta.Links.Self)
-				assertEqual(t, "?_offset=10&_limit=10", *got.Meta.Links.Next)
+				assertEqual(t, "?_offset=0&_limit=1", got.Meta.Links.Self)
+				assertEqual(t, true, got.Meta.Links.Next == nil)
+				assertEqual(t, true, got.Meta.Links.Previous == nil)
 
 				assertEqual(t, 1, len(got.Result))
 				peering := got.Result[0]
-				assertEqual(t, "peering-1", peering.ID)
-				assertEqual(t, "peering-prod-to-db", peering.Name)
-				assertEqual(t, "connection between production and database vpcs", *peering.Description)
-				assertEqual(t, VpcsPeeringStatusCreated, peering.Status)
+				assertEqual(t, "866b0e4d-59d7-42e6-82d7-aa5fcb72360d", peering.ID)
+				assertEqual(t, "name", peering.Name)
+				assertEqual(t, "desc", *peering.Description)
+				assertEqual(t, VpcsPeeringStatusPending, peering.Status)
 				assertEqual(t, true, time.Time(*peering.CreatedAt).Equal(createdAt))
 				assertEqual(t, true, time.Time(*peering.Updated).Equal(updated))
 
 				assertEqual(t, 2, len(peering.Members))
-				assertEqual(t, "member-1", peering.Members[0].ID)
-				assertEqual(t, "vpc-requester", peering.Members[0].VpcID)
+				assertEqual(t, "ec32dc9f-679d-4c25-9f3f-b0b37aa101a0", peering.Members[0].ID)
+				assertEqual(t, "2ea7d752-c185-422b-9780-2d07109d8afe", peering.Members[0].VpcID)
 				assertEqual(t, VpcsPeeringDirectRoleRequester, peering.Members[0].DirectRole)
 				assertEqual(t, VpcsPeeringDirectRoleAccepter, peering.Members[1].DirectRole)
 			},
 		},
 		{
+			name: "second page of peerings",
+			opts: &ListVpcsPeeringsOptions{
+				Limit:  helpers.IntPtr(1),
+				Offset: helpers.IntPtr(1),
+			},
+			wantQuery: map[string]string{"_limit": "1", "_offset": "1"},
+			response: `{
+				"meta": {
+					"links": {
+						"next": null,
+						"previous": "?_offset=0&_limit=1",
+						"self": "?_offset=1&_limit=1"
+					},
+					"page": {"count": 1, "limit": 1, "max_items_per_page": 100, "offset": 1, "total": 2}
+				},
+				"result": [
+					{"id": "peering-2", "name": "second", "status": "created", "members": []}
+				]
+			}`,
+			statusCode: http.StatusOK,
+			check: func(t *testing.T, got *ListVpcsPeeringsResponse) {
+				assertEqual(t, 1, got.Meta.Page.Offset)
+				assertEqual(t, 2, got.Meta.Page.Total)
+				assertEqual(t, "?_offset=0&_limit=1", *got.Meta.Links.Previous)
+				assertEqual(t, "peering-2", got.Result[0].ID)
+			},
+		},
+		{
 			name:      "peerings of a specific vpc",
 			opts:      &ListVpcsPeeringsOptions{VpcID: "vpc-requester"},
-			wantVpcID: "vpc-requester",
+			wantQuery: map[string]string{"vpc_id": "vpc-requester"},
 			response: `{
 				"meta": {
 					"links": {"self": "?_offset=0&_limit=10"},
@@ -324,7 +352,7 @@ func TestVpcsPeeringsService_List(t *testing.T) {
 		{
 			name:       "missing description becomes nil",
 			opts:       &ListVpcsPeeringsOptions{},
-			response:   `{"meta": {"links": {"self": "?"}, "page": {"count": 1, "limit": 10, "max_items_per_page": 100, "offset": 0, "total": 1}}, "result": [{"vpc_peering_id": "peering-2", "name": "peering-minimal", "status": "pending", "members": []}]}`,
+			response:   `{"meta": {"links": {"self": "?"}, "page": {"count": 1, "limit": 10, "max_items_per_page": 100, "offset": 0, "total": 1}}, "result": [{"id": "peering-2", "name": "peering-minimal", "status": "pending", "members": []}]}`,
 			statusCode: http.StatusOK,
 			check: func(t *testing.T, got *ListVpcsPeeringsResponse) {
 				peering := got.Result[0]
@@ -356,7 +384,12 @@ func TestVpcsPeeringsService_List(t *testing.T) {
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				assertEqual(t, "/network/v1/vpcs_peerings", r.URL.Path)
 				assertEqual(t, http.MethodGet, r.Method)
-				assertEqual(t, tt.wantVpcID, r.URL.Query().Get("vpc_id"))
+
+				query := r.URL.Query()
+				assertEqual(t, len(tt.wantQuery), len(query))
+				for param, want := range tt.wantQuery {
+					assertEqual(t, want, query.Get(param))
+				}
 
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(tt.statusCode)
@@ -390,32 +423,41 @@ func TestVpcsPeeringsService_GetMembers(t *testing.T) {
 	}{
 		{
 			name:      "members of both ends of the peering",
-			peeringID: "peering-1",
+			peeringID: "866b0e4d-59d7-42e6-82d7-aa5fcb72360d",
 			response: `{
-				"vpc_peering_id": "peering-1",
-				"status": "created",
 				"members": [
 					{
-						"id": "member-1",
-						"vpc_id": "vpc-requester",
-						"direct_role": "requester"
+						"direct_role": "requester",
+						"id": "ec32dc9f-679d-4c25-9f3f-b0b37aa101a0",
+						"vpc_id": "2ea7d752-c185-422b-9780-2d07109d8afe"
 					},
 					{
-						"id": "member-2",
-						"vpc_id": "vpc-accepter",
-						"direct_role": "accepter"
+						"direct_role": "accepter",
+						"id": "759afe65-f9d5-408e-a4ac-c430dbbd6d35",
+						"vpc_id": "732d0b32-b9c0-44da-8766-72044e59ef12"
 					}
-				]
+				],
+				"status": "pending_route_table",
+				"vpc_peering_id": "866b0e4d-59d7-42e6-82d7-aa5fcb72360d"
 			}`,
 			statusCode: http.StatusOK,
 			check: func(t *testing.T, got *VpcsPeeringMembers) {
-				assertEqual(t, "peering-1", got.ID)
-				assertEqual(t, VpcsPeeringStatusCreated, got.Status)
+				assertEqual(t, "866b0e4d-59d7-42e6-82d7-aa5fcb72360d", got.ID)
+				assertEqual(t, VpcsPeeringStatusPendingRouteTable, got.Status)
 				assertEqual(t, 2, len(got.Members))
-				assertEqual(t, "vpc-requester", got.Members[0].VpcID)
+				assertEqual(t, "2ea7d752-c185-422b-9780-2d07109d8afe", got.Members[0].VpcID)
 				assertEqual(t, VpcsPeeringDirectRoleRequester, got.Members[0].DirectRole)
-				assertEqual(t, "vpc-accepter", got.Members[1].VpcID)
+				assertEqual(t, "732d0b32-b9c0-44da-8766-72044e59ef12", got.Members[1].VpcID)
 				assertEqual(t, VpcsPeeringDirectRoleAccepter, got.Members[1].DirectRole)
+			},
+		},
+		{
+			name:       "status the SDK does not know yet",
+			peeringID:  "peering-3",
+			response:   `{"vpc_peering_id": "peering-3", "status": "some_future_status", "members": []}`,
+			statusCode: http.StatusOK,
+			check: func(t *testing.T, got *VpcsPeeringMembers) {
+				assertEqual(t, VpcsPeeringStatus("some_future_status"), got.Status)
 			},
 		},
 		{
@@ -429,7 +471,7 @@ func TestVpcsPeeringsService_GetMembers(t *testing.T) {
 			},
 		},
 		{
-			name:       "peering inexistente",
+			name:       "non-existent peering",
 			peeringID:  "invalid",
 			response:   `{"detail": "not found"}`,
 			statusCode: http.StatusNotFound,

--- a/network/vpcs_peerings_test.go
+++ b/network/vpcs_peerings_test.go
@@ -2,6 +2,7 @@ package network
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -128,6 +129,13 @@ func TestVpcsPeeringsService_Create(t *testing.T) {
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				assertEqual(t, "/network/v1/vpcs_peerings", r.URL.Path)
 				assertEqual(t, http.MethodPost, r.Method)
+				if tt.wantBody != "" {
+					body, err := io.ReadAll(r.Body)
+					if err != nil {
+						t.Errorf("failed to read request body: %v", err)
+					}
+					assertEqual(t, canonicalJSON(t, tt.wantBody), canonicalJSON(t, string(body)))
+				}
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(tt.statusCode)
 				w.Write([]byte(tt.response))
@@ -709,4 +717,20 @@ func testPeeringClient(baseURL string) VpcsPeeringsService {
 		client.WithHTTPClient(httpClient))
 
 	return New(core).VpcsPeerings()
+}
+
+func canonicalJSON(t *testing.T, raw string) string {
+	t.Helper()
+
+	var decoded any
+	if err := json.Unmarshal([]byte(raw), &decoded); err != nil {
+		t.Fatalf("invalid JSON %q: %v", raw, err)
+	}
+
+	encoded, err := json.Marshal(decoded)
+	if err != nil {
+		t.Fatalf("failed to encode JSON: %v", err)
+	}
+
+	return string(encoded)
 }

--- a/network/vpcs_routes.go
+++ b/network/vpcs_routes.go
@@ -43,7 +43,7 @@ type (
 
 	VpcsRoutesCreateRequest struct {
 		//DEPRECATED, will be removed shortly
-		PortID          *string        `json:"port_id"`
+		PortID          *string        `json:"port_id,omitempty"`
 		CIDRDestination string         `json:"cidr_destination"`
 		Description     *string        `json:"description"`
 		Targets         TargetsRequest `json:"targets"`

--- a/network/vpcs_routes.go
+++ b/network/vpcs_routes.go
@@ -42,8 +42,6 @@ type (
 	}
 
 	VpcsRoutesCreateRequest struct {
-		//DEPRECATED, use Targets instead
-		PortID          *string        `json:"port_id,omitempty"`
 		CIDRDestination string         `json:"cidr_destination"`
 		Description     *string        `json:"description"`
 		Targets         TargetsRequest `json:"targets"`
@@ -208,11 +206,6 @@ func (s *vpcsRoutesService) Get(ctx context.Context, vpcID, routeID string) (*Vp
 func (s *vpcsRoutesService) Create(ctx context.Context, vpcID string, req VpcsRoutesCreateRequest) (*VpcsRoutesCreateResponse, error) {
 	if req.Targets.ID == "" || req.Targets.Type == "" {
 		return nil, fmt.Errorf("targets id and type cannot be empty")
-	}
-
-	//This is a temporary adjustment and should be removed soon.
-	if req.Targets.Type == "port_id" {
-		req.PortID = &req.Targets.ID
 	}
 
 	if req.CIDRDestination == "" {

--- a/network/vpcs_routes.go
+++ b/network/vpcs_routes.go
@@ -27,7 +27,8 @@ const (
 type (
 	VpcsRouteDetail struct {
 		ID              string      `json:"id"`
-		PortID          string      `json:"port_id"`
+		PortID          string      `json:"port_id,omitempty"`
+		VPCPeeringID    string      `json:"vpc_peering_id,omitempty"`
 		CIDRDestination string      `json:"cidr_destination"`
 		Description     string      `json:"description,omitempty"`
 		NextHop         string      `json:"next_hop"`
@@ -41,9 +42,16 @@ type (
 	}
 
 	VpcsRoutesCreateRequest struct {
-		PortID          string  `json:"port_id"`
-		CIDRDestination string  `json:"cidr_destination"`
-		Description     *string `json:"description"`
+		//DEPRECATED, will be removed shortly
+		PortID          *string        `json:"port_id"`
+		CIDRDestination string         `json:"cidr_destination"`
+		Description     *string        `json:"description"`
+		Targets         TargetsRequest `json:"targets"`
+	}
+
+	TargetsRequest struct {
+		ID   string `json:"id"`
+		Type string `json:"type"`
 	}
 
 	VpcsRoutesCreateResponse struct {
@@ -198,9 +206,15 @@ func (s *vpcsRoutesService) Get(ctx context.Context, vpcID, routeID string) (*Vp
 }
 
 func (s *vpcsRoutesService) Create(ctx context.Context, vpcID string, req VpcsRoutesCreateRequest) (*VpcsRoutesCreateResponse, error) {
-	if req.PortID == "" {
-		return nil, fmt.Errorf("port_id cannot be empty")
+	if req.Targets.ID == "" || req.Targets.Type == "" {
+		return nil, fmt.Errorf("targets id and type cannot be empty")
 	}
+
+	//This is a temporary adjustment and should be removed soon.
+	if req.Targets.Type == "port_id" {
+		req.PortID = &req.Targets.ID
+	}
+
 	if req.CIDRDestination == "" {
 		return nil, fmt.Errorf("cidr_destination cannot be empty")
 	}

--- a/network/vpcs_routes.go
+++ b/network/vpcs_routes.go
@@ -42,7 +42,7 @@ type (
 	}
 
 	VpcsRoutesCreateRequest struct {
-		//DEPRECATED, will be removed shortly
+		//DEPRECATED, use Targets instead
 		PortID          *string        `json:"port_id,omitempty"`
 		CIDRDestination string         `json:"cidr_destination"`
 		Description     *string        `json:"description"`

--- a/network/vpcs_routes_test.go
+++ b/network/vpcs_routes_test.go
@@ -1308,8 +1308,11 @@ func TestRouteService_Create(t *testing.T) {
 			name:  "successful create",
 			vpcID: "vpc-1",
 			body: VpcsRoutesCreateRequest{
-				PortID:          "port-1",
 				CIDRDestination: "192.168.1.1",
+				Targets: TargetsRequest{
+					ID:   "port-1",
+					Type: "port",
+				},
 			},
 			response: `{
 				"id": "route-1",
@@ -1326,9 +1329,12 @@ func TestRouteService_Create(t *testing.T) {
 			name:  "successful create with description",
 			vpcID: "vpc-1",
 			body: VpcsRoutesCreateRequest{
-				PortID:          "port-1",
 				CIDRDestination: "192.168.1.1",
 				Description:     helpers.StrPtr("Description"),
+				Targets: TargetsRequest{
+					ID:   "port-1",
+					Type: "port",
+				},
 			},
 			response: `{
 				"id": "route-1",
@@ -1345,8 +1351,11 @@ func TestRouteService_Create(t *testing.T) {
 			name:  "non-existent vpc id",
 			vpcID: "invalid",
 			body: VpcsRoutesCreateRequest{
-				PortID:          "port-1",
 				CIDRDestination: "192.168.1.1",
+				Targets: TargetsRequest{
+					ID:   "port-1",
+					Type: "port",
+				},
 			},
 			response:   `{"error": "vpc id not found"}`,
 			statusCode: http.StatusNotFound,
@@ -1356,8 +1365,11 @@ func TestRouteService_Create(t *testing.T) {
 			name:  "server error",
 			vpcID: "vpc-1",
 			body: VpcsRoutesCreateRequest{
-				PortID:          "port-1",
 				CIDRDestination: "192.168.1.1",
+				Targets: TargetsRequest{
+					ID:   "port-1",
+					Type: "port",
+				},
 			},
 			response:   `{"error": "internal server error"}`,
 			statusCode: http.StatusInternalServerError,
@@ -1378,7 +1390,8 @@ func TestRouteService_Create(t *testing.T) {
 				assertNoError(t, err)
 
 				assertEqual(t, tt.body.CIDRDestination, req.CIDRDestination)
-				assertEqual(t, tt.body.PortID, req.PortID)
+				assertEqual(t, tt.body.Targets.ID, req.Targets.ID)
+				assertEqual(t, tt.body.Targets.Type, req.Targets.Type)
 
 				if tt.body.Description != nil {
 					assertEqual(t, *tt.body.Description, *req.Description)
@@ -1416,16 +1429,39 @@ func TestRouteService_Create_InvalidBody(t *testing.T) {
 		err  string
 	}{
 		{
-			name: "empty port_id",
+			name: "empty targets",
 			body: VpcsRoutesCreateRequest{
 				CIDRDestination: "192.168.1.1",
 			},
-			err: "port_id cannot be empty",
+			err: "targets id and type cannot be empty",
+		},
+		{
+			name: "empty targets id",
+			body: VpcsRoutesCreateRequest{
+				CIDRDestination: "192.168.1.1",
+				Targets: TargetsRequest{
+					Type: "port",
+				},
+			},
+			err: "targets id and type cannot be empty",
+		},
+		{
+			name: "empty targets type",
+			body: VpcsRoutesCreateRequest{
+				CIDRDestination: "192.168.1.1",
+				Targets: TargetsRequest{
+					ID: "port-1",
+				},
+			},
+			err: "targets id and type cannot be empty",
 		},
 		{
 			name: "empty cidr_destination",
 			body: VpcsRoutesCreateRequest{
-				PortID: "port-1",
+				Targets: TargetsRequest{
+					ID:   "port-1",
+					Type: "port",
+				},
 			},
 			err: "cidr_destination cannot be empty",
 		},


### PR DESCRIPTION
## What does this PR do?
Novo serviço VpcsPeerings

- Create — cria peering entre dois VPCs (requester_vpc_id / accepter_vpc_id)
- Get — busca peering por ID
- List — lista com filtro por vpc_id, sort e paginação (page, items_per_page)
- ListAll — percorre a paginação automaticamente (100 por página), com filtros VpcID/Sort
- Delete — remove peering por ID

Ajuste de contrato em vpcs_routes.go (para suportar rota apontando para peering):

- VpcsRoutesCreateRequest ganha Targets{ID, Type}; PortID vira *string e fica marcado como deprecated — quando Type == "port_id", o SDK ainda preenche PortID como compatibilidade temporária
- VpcsRouteDetail ganha VPCPeeringID e PortID passa a omitempty
- Validação trocada de port_id obrigatório para targets.id + targets.type
## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
