### PR TITLE
Feat/tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Validate version format
         id: validate-version
         run: |
-          if [[ ! ${{ github.event.inputs.version }} =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          if [[ ! ${{ github.event.inputs.version }} =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)\.[0-9]+)?$ ]]; then
             echo "Invalid version format. Must be in format v1.0.0"
             exit 1
           fi

--- a/cmd/examples/tag/main.go
+++ b/cmd/examples/tag/main.go
@@ -1,0 +1,299 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"math/rand/v2"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/MagaluCloud/mgc-sdk-go/client"
+	"github.com/MagaluCloud/mgc-sdk-go/helpers"
+	"github.com/MagaluCloud/mgc-sdk-go/tag"
+)
+
+func main() {
+	// Tags
+	ExampleListTags()
+	tagName := ExampleCreateTag()
+	ExampleGetTag(tagName)
+	ExampleUpdateTag(tagName)
+
+	// Tag values
+	valueName := ExampleCreateTagValue(tagName)
+	ExampleListTagValues(tagName)
+	ExampleGetTagValue(tagName, valueName)
+	ExampleUpdateTagValue(tagName, valueName)
+
+	// Resource types
+	ExampleListResourceTypes()
+
+	// Tagged resources. Resources belong to other products, so set MGC_RESOURCE_ID
+	// to the ID of one you already own to run the attach and detach examples.
+	ExampleListResources()
+	if externalID := os.Getenv("MGC_RESOURCE_ID"); externalID != "" {
+		ExampleAttachTags(externalID, tagName, valueName)
+		ExampleGetResource(externalID)
+		ExampleDetachTag(externalID, tagName)
+	}
+
+	// Cleanup
+	ExampleDeleteTagValue(tagName, valueName)
+	ExampleDeleteTag(tagName)
+}
+
+// newTagClient builds a tag client from the MGC_API_TOKEN environment variable.
+// Tags are a global service, so no region needs to be configured.
+func newTagClient() *tag.TagClient {
+	apiToken := os.Getenv("MGC_API_TOKEN")
+	if apiToken == "" {
+		log.Fatal("MGC_API_TOKEN environment variable is not set")
+	}
+
+	core := client.NewMgcClient(client.WithJWToken(apiToken))
+
+	// The API accepts a tenant override for accounts with more than one tenant.
+	var opts []tag.ClientOption
+	if tenantID := os.Getenv("MGC_TENANT_ID"); tenantID != "" {
+		opts = append(opts, tag.WithTenantID(tenantID))
+	}
+
+	return tag.New(core, opts...)
+}
+
+func ExampleListTags() {
+	tagClient := newTagClient()
+
+	tags, err := tagClient.Tags().List(context.Background(), tag.ListTagsOptions{
+		Kinds: []tag.TagKind{tag.TagKindFinops},
+		Limit: helpers.IntPtr(10),
+		Sort:  helpers.StrPtr("name:asc"),
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("Found %d tags:\n", len(tags))
+	for _, t := range tags {
+		fmt.Printf("  Tag: %s (color: %s, values: %d)\n", t.Name, deref(t.Color), len(t.Values))
+	}
+}
+
+func ExampleCreateTag() string {
+	tagClient := newTagClient()
+
+	t, err := tagClient.Tags().Create(context.Background(), tag.CreateTagRequest{
+		Name:        "environment_" + randomString(),
+		Description: helpers.StrPtr("Identifies the deployment environment"),
+		Color:       helpers.StrPtr("F54927"),
+		Kinds:       []tag.TagKind{tag.TagKindFinops},
+		Values: []tag.CreateTagValueRequest{
+			{Name: "production", Description: helpers.StrPtr("Production workloads")},
+		},
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("Created tag: %s (color: %s)\n", t.Name, deref(t.Color))
+	return t.Name
+}
+
+func ExampleGetTag(tagName string) {
+	tagClient := newTagClient()
+
+	t, err := tagClient.Tags().Get(context.Background(), tagName)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("Tag Details:\n")
+	fmt.Printf("  Name: %s\n", t.Name)
+	fmt.Printf("  Description: %s\n", deref(t.Description))
+	fmt.Printf("  Color: %s\n", deref(t.Color))
+	fmt.Printf("  Created At: %s\n", time.Time(t.CreatedAt))
+}
+
+func ExampleUpdateTag(tagName string) {
+	tagClient := newTagClient()
+
+	t, err := tagClient.Tags().Update(context.Background(), tagName, tag.UpdateTagRequest{
+		Description: helpers.StrPtr("Identifies the deployment environment (updated)"),
+		Color:       helpers.StrPtr("F54927"),
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("Updated tag: %s (color: %s)\n", t.Name, deref(t.Color))
+}
+
+func ExampleCreateTagValue(tagName string) string {
+	tagClient := newTagClient()
+
+	v, err := tagClient.Values().Create(context.Background(), tagName, tag.CreateTagValueRequest{
+		Name:        "staging",
+		Description: helpers.StrPtr("Staging workloads"),
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("Created value %q on tag %q\n", v.Name, tagName)
+	return v.Name
+}
+
+func ExampleListTagValues(tagName string) {
+	tagClient := newTagClient()
+
+	values, err := tagClient.Values().List(context.Background(), tagName, tag.ListTagValuesOptions{
+		Limit: helpers.IntPtr(10),
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("Tag %q has %d values:\n", tagName, len(values))
+	for _, v := range values {
+		fmt.Printf("  Value: %s - %s\n", v.Name, deref(v.Description))
+	}
+}
+
+func ExampleGetTagValue(tagName, valueName string) {
+	tagClient := newTagClient()
+
+	v, err := tagClient.Values().Get(context.Background(), tagName, valueName)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("Value Details:\n")
+	fmt.Printf("  Name: %s\n", v.Name)
+	fmt.Printf("  Description: %s\n", deref(v.Description))
+	if v.Tag != nil {
+		fmt.Printf("  Tag: %s\n", v.Tag.Name)
+	}
+}
+
+func ExampleUpdateTagValue(tagName, valueName string) {
+	tagClient := newTagClient()
+
+	v, err := tagClient.Values().Update(context.Background(), tagName, valueName, tag.UpdateTagValueRequest{
+		Description: helpers.StrPtr("Staging workloads (updated)"),
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("Updated value %q: %s\n", v.Name, deref(v.Description))
+}
+
+func ExampleListResourceTypes() {
+	tagClient := newTagClient()
+
+	product := tag.Product("network")
+	types, err := tagClient.ResourceTypes().List(context.Background(), tag.ListResourceTypesOptions{
+		Product: &product,
+		Limit:   helpers.IntPtr(10),
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("Found %d resource types for product %q:\n", len(types), product)
+	for _, rt := range types {
+		fmt.Printf("  Name: %s (product: %s)\n", rt.Name, rt.Product)
+	}
+}
+
+func ExampleListResources() {
+	tagClient := newTagClient()
+
+	resources, err := tagClient.Resources().List(context.Background(), tag.ListResourcesOptions{
+		Limit: helpers.IntPtr(10),
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("Found %d tagged resources:\n", len(resources))
+	for _, r := range resources {
+		fmt.Printf("  %s (%s, %s) with %d tags\n", r.ExternalID, r.ResourceType.Name, r.Region, len(r.Tags))
+	}
+}
+
+func ExampleGetResource(externalID string) {
+	tagClient := newTagClient()
+
+	resource, err := tagClient.Resources().Get(context.Background(), externalID)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("Resource Details:\n")
+	fmt.Printf("  External ID: %s\n", resource.ExternalID)
+	fmt.Printf("  Type: %s (product: %s)\n", resource.ResourceType.Name, resource.ResourceType.Product)
+	fmt.Printf("  Region: %s\n", resource.Region)
+	for _, t := range resource.Tags {
+		fmt.Printf("  Tag: %s = %s\n", t.Name, t.Value)
+	}
+}
+
+func ExampleAttachTags(externalID, tagName, valueName string) {
+	tagClient := newTagClient()
+
+	resource, err := tagClient.Resources().AttachTags(context.Background(), externalID, tag.AttachTagsRequest{
+		Tags: []tag.AttachTag{
+			{Name: tagName, Value: valueName},
+		},
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("Attached tag %q with value %q to resource %q, now with %d tags\n",
+		tagName, valueName, externalID, len(resource.Tags))
+}
+
+func ExampleDetachTag(externalID, tagName string) {
+	tagClient := newTagClient()
+
+	if err := tagClient.Resources().DetachTag(context.Background(), externalID, tagName); err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("Detached tag %q from resource %q\n", tagName, externalID)
+}
+
+func ExampleDeleteTagValue(tagName, valueName string) {
+	tagClient := newTagClient()
+
+	if err := tagClient.Values().Delete(context.Background(), tagName, valueName); err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("Deleted value %q from tag %q\n", valueName, tagName)
+}
+
+func ExampleDeleteTag(tagName string) {
+	tagClient := newTagClient()
+
+	if err := tagClient.Tags().Delete(context.Background(), tagName); err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("Deleted tag %q\n", tagName)
+}
+
+func deref(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
+}
+
+func randomString() string {
+	return strconv.FormatInt(time.Now().Unix(), 10) + strconv.FormatInt(rand.Int64(), 10)
+}

--- a/docs/main_generator.py
+++ b/docs/main_generator.py
@@ -36,7 +36,7 @@ class DocumentationGenerator:
         self.go_modules = [
             "client", "compute", "blockstorage", "network", "kubernetes",
             "dbaas", "containerregistry", "sshkeys", "availabilityzones",
-            "audit", "lbaas", "helpers"
+            "audit", "lbaas", "tag", "helpers"
         ]
 
     def get_project_version(self) -> str:
@@ -163,6 +163,7 @@ The MGC Go SDK provides a convenient way to interact with the Magalu Cloud API f
    modules/availabilityzones
    modules/audit
    modules/lbaas
+   modules/tag
    modules/helpers
 
 Indices and tables
@@ -521,6 +522,7 @@ mgc-sdk-go/
 ├── availabilityzones/ # Availability Zones service API
 ├── audit/          # Audit service API
 ├── lbaas/          # Load Balancer as a Service API
+├── tag/            # Tags service API
 ├── helpers/        # Utility functions
 ├── internal/       # Internal packages
 └── cmd/            # Usage examples
@@ -560,6 +562,9 @@ Provides functionality to access audit logs and events.
 
 ### lbaas/
 Allows managing load balancers and related configurations.
+
+### tag/
+Allows managing tags, their values, and the tags attached to the resources of other products.
 
 ### helpers/
 Contains reusable utility functions throughout the SDK.

--- a/tag/client.go
+++ b/tag/client.go
@@ -1,0 +1,107 @@
+// Package tag provides client implementation for managing tags in the Magalu Cloud platform.
+// Tags are managed as a global service, meaning they are not bound to any specific region.
+// By default, the service uses the global endpoint, but this can be overridden if needed.
+package tag
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/MagaluCloud/mgc-sdk-go/client"
+	mgc_http "github.com/MagaluCloud/mgc-sdk-go/internal/http"
+)
+
+const (
+	// DefaultBasePath is the default API base path for tag operations
+	DefaultBasePath = "/tags"
+)
+
+// TagClient represents a client for interacting with the tags service
+type TagClient struct {
+	*client.CoreClient
+	baseURL  client.MgcUrl
+	tenantID string
+}
+
+// ClientOption allows customizing the tag client configuration.
+type ClientOption func(*TagClient)
+
+// WithGlobalBasePath allows overriding the default global endpoint for the tags service.
+// This is rarely needed as tags are managed globally, but provided for flexibility.
+//
+// Example:
+//
+//	client := tag.New(core, tag.WithGlobalBasePath("https://tags.example.com"))
+func WithGlobalBasePath(basePath client.MgcUrl) ClientOption {
+	return func(c *TagClient) {
+		c.baseURL = basePath
+	}
+}
+
+// WithTenantID sets the x-tenant-id header sent by this client, for accounts that
+// own more than one tenant. It takes precedence over a header of the same name
+// configured in the core client.
+func WithTenantID(tenantID string) ClientOption {
+	return func(c *TagClient) {
+		c.tenantID = tenantID
+	}
+}
+
+// New creates a new tag client using the provided core client.
+// The tags service operates globally and is not region-specific, so the endpoint
+// configured in the core client is not used and is left untouched.
+// By default, it uses the global endpoint (api.magalu.cloud).
+//
+// To customize the endpoint, use the WithGlobalBasePath option.
+func New(core *client.CoreClient, opts ...ClientOption) *TagClient {
+	if core == nil {
+		return nil
+	}
+	tagClient := &TagClient{
+		CoreClient: core,
+		baseURL:    client.Global,
+	}
+
+	for _, opt := range opts {
+		opt(tagClient)
+	}
+	return tagClient
+}
+
+// newRequest creates a new HTTP request with the tags API base path.
+// The endpoint is applied to a copy of the configuration, so the core client,
+// which is shared with the other services, keeps the endpoint of its own region.
+func (c *TagClient) newRequest(ctx context.Context, method, path string, body any) (*http.Request, error) {
+	config := *c.GetConfig()
+	config.BaseURL = c.baseURL
+
+	req, err := mgc_http.NewRequest(&config, ctx, method, DefaultBasePath+path, &body)
+	if err != nil {
+		return nil, err
+	}
+
+	if c.tenantID != "" {
+		req.Header.Set("x-tenant-id", c.tenantID)
+	}
+	return req, nil
+}
+
+// Tags returns a service for managing tag resources
+func (c *TagClient) Tags() TagService {
+	return &tagService{client: c}
+}
+
+// Values returns a service for managing the values of a tag
+func (c *TagClient) Values() TagValueService {
+	return &tagValueService{client: c}
+}
+
+// ResourceTypes returns a service for listing the resource types that support tagging
+func (c *TagClient) ResourceTypes() ResourceTypeService {
+	return &resourceTypeService{client: c}
+}
+
+// Resources returns a service for managing the tags attached to resources
+func (c *TagClient) Resources() ResourceService {
+	return &resourceService{client: c}
+}

--- a/tag/client_test.go
+++ b/tag/client_test.go
@@ -1,0 +1,195 @@
+package tag
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/MagaluCloud/mgc-sdk-go/client"
+)
+
+// Helper functions
+func assertEqual(t *testing.T, expected, actual interface{}, msgAndArgs ...interface{}) {
+	t.Helper()
+	if expected != actual {
+		t.Errorf("Expected %v but got %v. %v", expected, actual, msgAndArgs)
+	}
+}
+
+func assertError(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		t.Error("Expected error but got nil")
+	}
+}
+
+func assertNoError(t *testing.T, err error) {
+	t.Helper()
+	if err != nil {
+		t.Errorf("Expected no error but got: %v", err)
+	}
+}
+
+// assertValidationError checks that err is a *client.ValidationError for the given API field.
+func assertValidationError(t *testing.T, err error, field string) {
+	t.Helper()
+	validationErr, ok := err.(*client.ValidationError)
+	if !ok {
+		t.Fatalf("Expected *client.ValidationError but got %T: %v", err, err)
+	}
+	assertEqual(t, field, validationErr.Field)
+}
+
+// canonicalJSON re-encodes a JSON document so two encodings of the same object compare equal.
+func canonicalJSON(t *testing.T, raw string) string {
+	t.Helper()
+	var v any
+	if err := json.Unmarshal([]byte(raw), &v); err != nil {
+		t.Fatalf("invalid JSON %q: %v", raw, err)
+	}
+	out, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("could not re-encode JSON: %v", err)
+	}
+	return string(out)
+}
+
+func testTagClient(baseURL string) *TagClient {
+	core := client.NewMgcClient(
+		client.WithAPIKey("test-api-key"),
+		client.WithHTTPClient(&http.Client{}),
+	)
+	return New(core, WithGlobalBasePath(client.MgcUrl(baseURL)))
+}
+
+func TestNew(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil core returns nil", func(t *testing.T) {
+		t.Parallel()
+
+		if New(nil) != nil {
+			t.Error("Expected nil client for nil core")
+		}
+	})
+
+	t.Run("defaults to the global endpoint", func(t *testing.T) {
+		t.Parallel()
+
+		core := client.NewMgcClient(client.WithAPIKey("test-api-key"))
+		tagClient := New(core)
+
+		req, err := tagClient.newRequest(context.Background(), http.MethodGet, "/v0/tags", nil)
+
+		assertNoError(t, err)
+		assertEqual(t, client.Global.String()+"/tags/v0/tags", req.URL.String())
+		assertEqual(t, core, tagClient.CoreClient)
+	})
+
+	t.Run("global base path can be overridden", func(t *testing.T) {
+		t.Parallel()
+
+		core := client.NewMgcClient(client.WithAPIKey("test-api-key"))
+		tagClient := New(core, WithGlobalBasePath("https://tags.example.com"))
+
+		req, err := tagClient.newRequest(context.Background(), http.MethodGet, "/v0/tags", nil)
+
+		assertNoError(t, err)
+		assertEqual(t, "https://tags.example.com/tags/v0/tags", req.URL.String())
+	})
+
+	t.Run("keeps the endpoint of the core client, which is shared with other services", func(t *testing.T) {
+		t.Parallel()
+
+		core := client.NewMgcClient(client.WithBaseURL(client.BrNe1))
+
+		tagClient := New(core)
+		if _, err := tagClient.newRequest(context.Background(), http.MethodGet, "/v0/tags", nil); err != nil {
+			t.Fatalf("Expected no error but got: %v", err)
+		}
+
+		assertEqual(t, client.BrNe1, core.GetConfig().BaseURL)
+	})
+
+	t.Run("keeps the credentials and transport configured by the caller", func(t *testing.T) {
+		t.Parallel()
+
+		core := client.NewMgcClient(
+			client.WithJWToken("Bearer caller-token"),
+			client.WithCustomHeader("x-tenant-id", "caller-tenant"),
+		)
+		callerTransport := core.GetConfig().HTTPClient.Transport
+
+		New(core)
+
+		assertEqual(t, "Bearer caller-token", core.GetConfig().JWToken)
+		assertEqual(t, "caller-tenant", core.GetConfig().CustomHeaders["x-tenant-id"])
+		assertEqual(t, callerTransport, core.GetConfig().HTTPClient.Transport)
+	})
+}
+
+func TestTagClient_newRequest(t *testing.T) {
+	t.Parallel()
+
+	t.Run("prefixes the path with the tags base path", func(t *testing.T) {
+		t.Parallel()
+
+		req, err := testTagClient("https://tags.example.com").
+			newRequest(context.Background(), http.MethodGet, "/v0/tags", nil)
+
+		assertNoError(t, err)
+		assertEqual(t, "https://tags.example.com/tags/v0/tags", req.URL.String())
+		assertEqual(t, "test-api-key", req.Header.Get("X-API-Key"))
+		assertEqual(t, "application/json", req.Header.Get("Content-Type"))
+	})
+
+	t.Run("sends the tenant configured in the client", func(t *testing.T) {
+		t.Parallel()
+
+		core := client.NewMgcClient(client.WithCustomHeader("x-tenant-id", "core-tenant"))
+		req, err := New(core, WithTenantID("tag-tenant")).
+			newRequest(context.Background(), http.MethodGet, "/v0/tags", nil)
+
+		assertNoError(t, err)
+		assertEqual(t, "tag-tenant", req.Header.Get("x-tenant-id"))
+	})
+
+	t.Run("without a tenant the header of the core client is kept", func(t *testing.T) {
+		t.Parallel()
+
+		core := client.NewMgcClient(client.WithCustomHeader("x-tenant-id", "core-tenant"))
+		req, err := New(core).newRequest(context.Background(), http.MethodGet, "/v0/tags", nil)
+
+		assertNoError(t, err)
+		assertEqual(t, "core-tenant", req.Header.Get("x-tenant-id"))
+	})
+
+	t.Run("body that cannot be encoded returns error", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := testTagClient("https://tags.example.com").
+			newRequest(context.Background(), http.MethodPost, "/v0/tags", make(chan int))
+
+		assertError(t, err)
+	})
+}
+
+func TestTagClient_Services(t *testing.T) {
+	t.Parallel()
+
+	tagClient := testTagClient("https://tags.example.com")
+
+	if _, ok := tagClient.Tags().(*tagService); !ok {
+		t.Error("Tags() did not return a *tagService")
+	}
+	if _, ok := tagClient.Values().(*tagValueService); !ok {
+		t.Error("Values() did not return a *tagValueService")
+	}
+	if _, ok := tagClient.ResourceTypes().(*resourceTypeService); !ok {
+		t.Error("ResourceTypes() did not return a *resourceTypeService")
+	}
+	if _, ok := tagClient.Resources().(*resourceService); !ok {
+		t.Error("Resources() did not return a *resourceService")
+	}
+}

--- a/tag/commons.go
+++ b/tag/commons.go
@@ -1,0 +1,49 @@
+package tag
+
+import (
+	"net/url"
+	"strconv"
+)
+
+// TagKind describes what a tag is used for.
+// The API may return kinds beyond the constants below.
+type TagKind string
+
+const (
+	TagKindFinops TagKind = "finops"
+)
+
+// Product identifies the product that owns a resource type, as in "virtual-machine".
+// The products that support tags are the ones returned by ResourceTypes().List.
+type Product string
+
+// ResourceTypeName identifies a type of resource that supports tagging, prefixed by
+// the product that owns it, as in "vm.instance".
+// The types that support tags are the ones returned by ResourceTypes().List, and grow
+// as products adopt tagging.
+type ResourceTypeName string
+
+// ResourceTypeUnknown is the type of a resource the API does not recognize.
+const ResourceTypeUnknown ResourceTypeName = "un.unknown"
+
+// listOptions holds the pagination parameters accepted by every list endpoint.
+type listOptions struct {
+	Limit  *int
+	Offset *int
+	Sort   *string
+}
+
+// makeListQuery builds the pagination query shared by every list endpoint.
+func makeListQuery(opts listOptions) url.Values {
+	query := make(url.Values)
+	if opts.Limit != nil {
+		query.Set("_limit", strconv.Itoa(*opts.Limit))
+	}
+	if opts.Offset != nil {
+		query.Set("_offset", strconv.Itoa(*opts.Offset))
+	}
+	if opts.Sort != nil {
+		query.Set("_sort", *opts.Sort)
+	}
+	return query
+}

--- a/tag/resource_types.go
+++ b/tag/resource_types.go
@@ -1,0 +1,72 @@
+package tag
+
+import (
+	"context"
+	"net/http"
+
+	mgc_http "github.com/MagaluCloud/mgc-sdk-go/internal/http"
+	"github.com/MagaluCloud/mgc-sdk-go/internal/utils"
+)
+
+type (
+	// ResourceType represents a resource type that supports tagging.
+	ResourceType struct {
+		Name      ResourceTypeName                `json:"name"`
+		Product   Product                         `json:"product"`
+		CreatedAt utils.LocalDateTimeWithoutZone  `json:"created_at"`
+		UpdatedAt *utils.LocalDateTimeWithoutZone `json:"updated_at"`
+	}
+
+	// ListResourceTypesResponse represents the response of a resource type listing
+	ListResourceTypesResponse struct {
+		Results []ResourceType `json:"results"`
+	}
+
+	// ListResourceTypesOptions defines the filters and pagination accepted when
+	// listing resource types.
+	ListResourceTypesOptions struct {
+		Name    *ResourceTypeName
+		Product *Product
+		Limit   *int
+		Offset  *int
+		Sort    *string
+	}
+)
+
+// ResourceTypeService provides methods for listing the resource types that support tagging.
+type ResourceTypeService interface {
+	// List retrieves the resource types and the product that owns each one. The API
+	// returns at most 100 items per call and defaults to 20, so use Limit and Offset
+	// to page through the results.
+	List(ctx context.Context, opts ListResourceTypesOptions) ([]ResourceType, error)
+}
+
+// resourceTypeService implements the ResourceTypeService interface
+type resourceTypeService struct {
+	client *TagClient
+}
+
+func (s *resourceTypeService) List(ctx context.Context, opts ListResourceTypesOptions) ([]ResourceType, error) {
+	query := makeListQuery(listOptions{Limit: opts.Limit, Offset: opts.Offset, Sort: opts.Sort})
+
+	if opts.Name != nil {
+		query.Set("name", string(*opts.Name))
+	}
+	if opts.Product != nil {
+		query.Set("product", string(*opts.Product))
+	}
+
+	result, err := mgc_http.ExecuteSimpleRequestWithRespBody[ListResourceTypesResponse](
+		ctx,
+		s.client.newRequest,
+		s.client.GetConfig(),
+		http.MethodGet,
+		"/v0/resource-types",
+		nil,
+		query,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return result.Results, nil
+}

--- a/tag/resource_types_test.go
+++ b/tag/resource_types_test.go
@@ -1,0 +1,129 @@
+package tag
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/MagaluCloud/mgc-sdk-go/helpers"
+)
+
+func TestResourceTypeService_List(t *testing.T) {
+	t.Parallel()
+
+	t.Run("resource types with their products", func(t *testing.T) {
+		t.Parallel()
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assertEqual(t, "/tags/v0/resource-types", r.URL.Path)
+			assertEqual(t, http.MethodGet, r.Method)
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"results": [
+				{
+					"name": "vm.instance",
+					"product": "virtual-machine",
+					"created_at": "2025-06-20T18:36:18.919454",
+					"updated_at": null
+				},
+				{
+					"name": "os.bucket",
+					"product": "object-storage",
+					"created_at": "2025-06-20T18:36:18.919454",
+					"updated_at": "2025-06-21T18:36:18.919454"
+				}
+			]}`))
+		}))
+		defer server.Close()
+
+		resourceTypes, err := testTagClient(server.URL).ResourceTypes().
+			List(context.Background(), ListResourceTypesOptions{})
+
+		assertNoError(t, err)
+		assertEqual(t, 2, len(resourceTypes))
+		assertEqual(t, ResourceTypeName("vm.instance"), resourceTypes[0].Name)
+		assertEqual(t, Product("virtual-machine"), resourceTypes[0].Product)
+		assertEqual(t, "2025-06-20T18:36:18.919454", formatTime(t, resourceTypes[0].CreatedAt))
+		if resourceTypes[0].UpdatedAt != nil {
+			t.Error("Expected a resource type never updated to have a nil UpdatedAt")
+		}
+		assertEqual(t, ResourceTypeName("os.bucket"), resourceTypes[1].Name)
+		assertEqual(t, Product("object-storage"), resourceTypes[1].Product)
+	})
+
+	t.Run("filters and pagination", func(t *testing.T) {
+		t.Parallel()
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			query := r.URL.Query()
+			assertEqual(t, 5, len(query))
+			assertEqual(t, "k8s.cluster", query.Get("name"))
+			assertEqual(t, "kubernetes", query.Get("product"))
+			assertEqual(t, "50", query.Get("_limit"))
+			assertEqual(t, "0", query.Get("_offset"))
+			assertEqual(t, "name:asc", query.Get("_sort"))
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"results": []}`))
+		}))
+		defer server.Close()
+
+		name := ResourceTypeName("k8s.cluster")
+		product := Product("kubernetes")
+		_, err := testTagClient(server.URL).ResourceTypes().
+			List(context.Background(), ListResourceTypesOptions{
+				Name:    &name,
+				Product: &product,
+				Limit:   helpers.IntPtr(50),
+				Offset:  helpers.IntPtr(0),
+				Sort:    helpers.StrPtr("name:asc"),
+			})
+
+		assertNoError(t, err)
+	})
+
+	t.Run("no filters sends no query", func(t *testing.T) {
+		t.Parallel()
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assertEqual(t, 0, len(r.URL.Query()))
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"results": []}`))
+		}))
+		defer server.Close()
+
+		_, err := testTagClient(server.URL).ResourceTypes().
+			List(context.Background(), ListResourceTypesOptions{})
+
+		assertNoError(t, err)
+	})
+
+	t.Run("invalid response body", func(t *testing.T) {
+		t.Parallel()
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"results": {}}`))
+		}))
+		defer server.Close()
+
+		_, err := testTagClient(server.URL).ResourceTypes().
+			List(context.Background(), ListResourceTypesOptions{})
+
+		assertError(t, err)
+	})
+
+	t.Run("api failure is retried and then reported", func(t *testing.T) {
+		t.Parallel()
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte(`{"error": "server error"}`))
+		}))
+		defer server.Close()
+
+		_, err := testTagClient(server.URL).ResourceTypes().
+			List(context.Background(), ListResourceTypesOptions{})
+
+		assertError(t, err)
+	})
+}

--- a/tag/resources.go
+++ b/tag/resources.go
@@ -1,0 +1,195 @@
+package tag
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/MagaluCloud/mgc-sdk-go/client"
+	mgc_http "github.com/MagaluCloud/mgc-sdk-go/internal/http"
+	"github.com/MagaluCloud/mgc-sdk-go/internal/utils"
+)
+
+type (
+	// ResourceTypeSummary identifies the type of a tagged resource.
+	ResourceTypeSummary struct {
+		Name    ResourceTypeName `json:"name"`
+		Product Product          `json:"product"`
+	}
+
+	// ResourceTag represents a tag attached to a resource and the value chosen for it.
+	ResourceTag struct {
+		Name  string `json:"name"`
+		Value string `json:"value"`
+	}
+
+	// Resource represents a resource of another product that can carry tags.
+	// ExternalID is the ID the owning product uses for it, and is what identifies
+	// the resource in every operation of this service.
+	Resource struct {
+		ID           string                          `json:"id"`
+		ExternalID   string                          `json:"external_id"`
+		ResourceType ResourceTypeSummary             `json:"resource_type"`
+		Region       string                          `json:"region"`
+		CreatedAt    utils.LocalDateTimeWithoutZone  `json:"created_at"`
+		UpdatedAt    *utils.LocalDateTimeWithoutZone `json:"updated_at"`
+		// LastTagAssociatedAt is nil while no tag was ever attached or detached.
+		LastTagAssociatedAt *utils.LocalDateTimeWithoutZone `json:"last_tag_associated_at"`
+		Tags                []ResourceTag                   `json:"tags"`
+	}
+
+	// ListResourcesResponse represents the response of a tagged resource listing
+	ListResourcesResponse struct {
+		Results []Resource `json:"results"`
+	}
+
+	// ListResourcesOptions defines the filters and pagination accepted when listing
+	// tagged resources.
+	ListResourcesOptions struct {
+		ExternalID       *string
+		ResourceTypeName *ResourceTypeName
+		Region           *string
+		Limit            *int
+		Offset           *int
+		Sort             *string
+	}
+
+	// AttachTag identifies a tag and the value to attach to a resource
+	AttachTag struct {
+		Name  string `json:"name"`
+		Value string `json:"value"`
+	}
+
+	// AttachTagsRequest represents the parameters for attaching tags to a resource
+	AttachTagsRequest struct {
+		Tags []AttachTag `json:"tags"`
+	}
+)
+
+// ResourceService provides methods for managing the tags attached to the resources
+// of other products.
+type ResourceService interface {
+	// List retrieves the resources that carry tags. The API returns at most 100 items
+	// per call and defaults to 20, so use Limit and Offset to page through the results.
+	List(ctx context.Context, opts ListResourcesOptions) ([]Resource, error)
+	// Get retrieves a resource and the tags attached to it.
+	Get(ctx context.Context, externalID string) (*Resource, error)
+	// AttachTags attaches tags to a resource and returns the resource with every tag
+	// it carries afterwards. A resource carries a single value per tag, so each tag
+	// has to be paired with the value it takes.
+	AttachTags(ctx context.Context, externalID string, req AttachTagsRequest) (*Resource, error)
+	// DetachTag removes a tag, and the value it carried, from a resource.
+	DetachTag(ctx context.Context, externalID, tagName string) error
+}
+
+// resourceService implements the ResourceService interface
+type resourceService struct {
+	client *TagClient
+}
+
+func (s *resourceService) List(ctx context.Context, opts ListResourcesOptions) ([]Resource, error) {
+	query := makeListQuery(listOptions{Limit: opts.Limit, Offset: opts.Offset, Sort: opts.Sort})
+
+	if opts.ExternalID != nil {
+		query.Set("external_id", *opts.ExternalID)
+	}
+	if opts.ResourceTypeName != nil {
+		query.Set("resource_type_name", string(*opts.ResourceTypeName))
+	}
+	if opts.Region != nil {
+		query.Set("region", *opts.Region)
+	}
+
+	result, err := mgc_http.ExecuteSimpleRequestWithRespBody[ListResourcesResponse](
+		ctx,
+		s.client.newRequest,
+		s.client.GetConfig(),
+		http.MethodGet,
+		"/v0/resources",
+		nil,
+		query,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return result.Results, nil
+}
+
+func (s *resourceService) Get(ctx context.Context, externalID string) (*Resource, error) {
+	if externalID == "" {
+		return nil, &client.ValidationError{Field: "external_id", Message: "cannot be empty"}
+	}
+
+	return mgc_http.ExecuteSimpleRequestWithRespBody[Resource](
+		ctx,
+		s.client.newRequest,
+		s.client.GetConfig(),
+		http.MethodGet,
+		resourcePath(externalID),
+		nil,
+		nil,
+	)
+}
+
+func (s *resourceService) AttachTags(ctx context.Context, externalID string, req AttachTagsRequest) (*Resource, error) {
+	if externalID == "" {
+		return nil, &client.ValidationError{Field: "external_id", Message: "cannot be empty"}
+	}
+	if len(req.Tags) == 0 {
+		return nil, &client.ValidationError{Field: "tags", Message: "must have at least one tag"}
+	}
+	for i, tag := range req.Tags {
+		if tag.Name == "" {
+			return nil, &client.ValidationError{
+				Field:   fmt.Sprintf("tags[%d].name", i),
+				Message: "cannot be empty",
+			}
+		}
+		if tag.Value == "" {
+			return nil, &client.ValidationError{
+				Field:   fmt.Sprintf("tags[%d].value", i),
+				Message: "cannot be empty",
+			}
+		}
+	}
+
+	return mgc_http.ExecuteSimpleRequestWithRespBody[Resource](
+		ctx,
+		s.client.newRequest,
+		s.client.GetConfig(),
+		http.MethodPost,
+		resourceTagsPath(externalID),
+		req,
+		nil,
+	)
+}
+
+func (s *resourceService) DetachTag(ctx context.Context, externalID, tagName string) error {
+	if externalID == "" {
+		return &client.ValidationError{Field: "external_id", Message: "cannot be empty"}
+	}
+	if tagName == "" {
+		return &client.ValidationError{Field: "tag_name", Message: "cannot be empty"}
+	}
+
+	return mgc_http.ExecuteSimpleRequest(
+		ctx,
+		s.client.newRequest,
+		s.client.GetConfig(),
+		http.MethodDelete,
+		resourceTagsPath(externalID)+"/"+url.PathEscape(tagName),
+		nil,
+		nil,
+	)
+}
+
+// resourcePath builds the path of a resource. External IDs are minted by each
+// product and may contain slashes, so they have to be escaped.
+func resourcePath(externalID string) string {
+	return "/v0/resources/" + url.PathEscape(externalID)
+}
+
+func resourceTagsPath(externalID string) string {
+	return resourcePath(externalID) + "/tags"
+}

--- a/tag/resources_test.go
+++ b/tag/resources_test.go
@@ -1,0 +1,444 @@
+package tag
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/MagaluCloud/mgc-sdk-go/helpers"
+)
+
+const resourcePayload = `{
+	"id": "31201f93-f5f4-4cf1-ba9c-bfed0717f4ac",
+	"external_id": "d9f3a1b2-6c5d-4e8f-9a0b-1c2d3e4f5a6b",
+	"resource_type": {
+		"name": "vm.instance",
+		"product": "virtual-machine"
+	},
+	"region": "br-se1",
+	"created_at": "2025-06-20T18:36:18.919454",
+	"updated_at": null,
+	"last_tag_associated_at": "2025-06-23T18:36:18.919454",
+	"tags": [
+		{"name": "kubernetes-expenses", "value": "test-labs"},
+		{"name": "environment", "value": "production"}
+	]
+}`
+
+func TestResourceService_List(t *testing.T) {
+	t.Parallel()
+
+	t.Run("tagged resources with their tags", func(t *testing.T) {
+		t.Parallel()
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assertEqual(t, "/tags/v0/resources", r.URL.Path)
+			assertEqual(t, http.MethodGet, r.Method)
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"results": [` + resourcePayload + `]}`))
+		}))
+		defer server.Close()
+
+		resources, err := testTagClient(server.URL).Resources().
+			List(context.Background(), ListResourcesOptions{})
+
+		assertNoError(t, err)
+		assertEqual(t, 1, len(resources))
+
+		resource := resources[0]
+		assertEqual(t, "31201f93-f5f4-4cf1-ba9c-bfed0717f4ac", resource.ID)
+		assertEqual(t, "d9f3a1b2-6c5d-4e8f-9a0b-1c2d3e4f5a6b", resource.ExternalID)
+		assertEqual(t, ResourceTypeName("vm.instance"), resource.ResourceType.Name)
+		assertEqual(t, Product("virtual-machine"), resource.ResourceType.Product)
+		assertEqual(t, "br-se1", resource.Region)
+		assertEqual(t, "2025-06-20T18:36:18.919454", formatTime(t, resource.CreatedAt))
+		if resource.UpdatedAt != nil {
+			t.Error("Expected a resource never updated to have a nil UpdatedAt")
+		}
+		if resource.LastTagAssociatedAt == nil {
+			t.Fatal("Expected LastTagAssociatedAt to be set")
+		}
+		assertEqual(t, "2025-06-23T18:36:18.919454", formatTime(t, *resource.LastTagAssociatedAt))
+		assertEqual(t, 2, len(resource.Tags))
+		assertEqual(t, "kubernetes-expenses", resource.Tags[0].Name)
+		assertEqual(t, "test-labs", resource.Tags[0].Value)
+		assertEqual(t, "environment", resource.Tags[1].Name)
+		assertEqual(t, "production", resource.Tags[1].Value)
+	})
+
+	t.Run("resource that never had a tag attached", func(t *testing.T) {
+		t.Parallel()
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"results": [{
+				"id": "31201f93-f5f4-4cf1-ba9c-bfed0717f4ac",
+				"external_id": "d9f3a1b2-6c5d-4e8f-9a0b-1c2d3e4f5a6b",
+				"resource_type": {"name": "os.bucket", "product": "object-storage"},
+				"region": "global",
+				"created_at": "2025-06-20T18:36:18.919454",
+				"updated_at": null,
+				"last_tag_associated_at": null,
+				"tags": []
+			}]}`))
+		}))
+		defer server.Close()
+
+		resources, err := testTagClient(server.URL).Resources().
+			List(context.Background(), ListResourcesOptions{})
+
+		assertNoError(t, err)
+		if resources[0].LastTagAssociatedAt != nil {
+			t.Error("Expected LastTagAssociatedAt to be nil")
+		}
+		assertEqual(t, 0, len(resources[0].Tags))
+	})
+
+	t.Run("filters and pagination", func(t *testing.T) {
+		t.Parallel()
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			query := r.URL.Query()
+			assertEqual(t, 6, len(query))
+			assertEqual(t, "d9f3a1b2-6c5d-4e8f-9a0b-1c2d3e4f5a6b", query.Get("external_id"))
+			assertEqual(t, "k8s.cluster", query.Get("resource_type_name"))
+			assertEqual(t, "br-ne1", query.Get("region"))
+			assertEqual(t, "50", query.Get("_limit"))
+			assertEqual(t, "10", query.Get("_offset"))
+			assertEqual(t, "external_id:asc", query.Get("_sort"))
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"results": []}`))
+		}))
+		defer server.Close()
+
+		resourceTypeName := ResourceTypeName("k8s.cluster")
+		_, err := testTagClient(server.URL).Resources().
+			List(context.Background(), ListResourcesOptions{
+				ExternalID:       helpers.StrPtr("d9f3a1b2-6c5d-4e8f-9a0b-1c2d3e4f5a6b"),
+				ResourceTypeName: &resourceTypeName,
+				Region:           helpers.StrPtr("br-ne1"),
+				Limit:            helpers.IntPtr(50),
+				Offset:           helpers.IntPtr(10),
+				Sort:             helpers.StrPtr("external_id:asc"),
+			})
+
+		assertNoError(t, err)
+	})
+
+	t.Run("no filters sends no query", func(t *testing.T) {
+		t.Parallel()
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assertEqual(t, 0, len(r.URL.Query()))
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"results": []}`))
+		}))
+		defer server.Close()
+
+		_, err := testTagClient(server.URL).Resources().
+			List(context.Background(), ListResourcesOptions{})
+
+		assertNoError(t, err)
+	})
+
+	t.Run("invalid response body", func(t *testing.T) {
+		t.Parallel()
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"results": {}}`))
+		}))
+		defer server.Close()
+
+		_, err := testTagClient(server.URL).Resources().
+			List(context.Background(), ListResourcesOptions{})
+
+		assertError(t, err)
+	})
+
+	t.Run("api failure is reported", func(t *testing.T) {
+		t.Parallel()
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnprocessableEntity)
+			w.Write([]byte(`{"detail": [{"loc": ["query", "region"], "msg": "invalid region"}]}`))
+		}))
+		defer server.Close()
+
+		_, err := testTagClient(server.URL).Resources().
+			List(context.Background(), ListResourcesOptions{})
+
+		assertError(t, err)
+	})
+}
+
+func TestResourceService_Get(t *testing.T) {
+	t.Parallel()
+
+	t.Run("resource with its tags", func(t *testing.T) {
+		t.Parallel()
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assertEqual(t, "/tags/v0/resources/d9f3a1b2-6c5d-4e8f-9a0b-1c2d3e4f5a6b", r.URL.Path)
+			assertEqual(t, http.MethodGet, r.Method)
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(resourcePayload))
+		}))
+		defer server.Close()
+
+		resource, err := testTagClient(server.URL).Resources().
+			Get(context.Background(), "d9f3a1b2-6c5d-4e8f-9a0b-1c2d3e4f5a6b")
+
+		assertNoError(t, err)
+		assertEqual(t, ResourceTypeName("vm.instance"), resource.ResourceType.Name)
+		assertEqual(t, 2, len(resource.Tags))
+	})
+
+	t.Run("external ID with characters that need escaping", func(t *testing.T) {
+		t.Parallel()
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assertEqual(t, "/tags/v0/resources/my-bucket%2Freports%2Fjune.csv", r.URL.EscapedPath())
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(resourcePayload))
+		}))
+		defer server.Close()
+
+		_, err := testTagClient(server.URL).Resources().
+			Get(context.Background(), "my-bucket/reports/june.csv")
+
+		assertNoError(t, err)
+	})
+
+	t.Run("empty external ID is rejected before the request", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := testTagClient("https://tags.example.com").Resources().
+			Get(context.Background(), "")
+
+		assertValidationError(t, err, "external_id")
+	})
+
+	t.Run("api failure is reported", func(t *testing.T) {
+		t.Parallel()
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnprocessableEntity)
+			w.Write([]byte(`{"detail": "not a valid resource"}`))
+		}))
+		defer server.Close()
+
+		_, err := testTagClient(server.URL).Resources().
+			Get(context.Background(), "d9f3a1b2-6c5d-4e8f-9a0b-1c2d3e4f5a6b")
+
+		assertError(t, err)
+	})
+}
+
+func TestResourceService_AttachTags(t *testing.T) {
+	t.Parallel()
+
+	t.Run("attaches tags and their values", func(t *testing.T) {
+		t.Parallel()
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assertEqual(t, "/tags/v0/resources/d9f3a1b2-6c5d-4e8f-9a0b-1c2d3e4f5a6b/tags", r.URL.Path)
+			assertEqual(t, http.MethodPost, r.Method)
+
+			body, err := io.ReadAll(r.Body)
+			assertNoError(t, err)
+			expected := `{"tags": [
+				{"name": "kubernetes-expenses", "value": "test-labs"},
+				{"name": "environment", "value": "production"}
+			]}`
+			assertEqual(t, canonicalJSON(t, expected), canonicalJSON(t, string(body)))
+
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(resourcePayload))
+		}))
+		defer server.Close()
+
+		resource, err := testTagClient(server.URL).Resources().
+			AttachTags(context.Background(), "d9f3a1b2-6c5d-4e8f-9a0b-1c2d3e4f5a6b", AttachTagsRequest{
+				Tags: []AttachTag{
+					{Name: "kubernetes-expenses", Value: "test-labs"},
+					{Name: "environment", Value: "production"},
+				},
+			})
+
+		assertNoError(t, err)
+		assertEqual(t, 2, len(resource.Tags))
+		assertEqual(t, "kubernetes-expenses", resource.Tags[0].Name)
+		assertEqual(t, "test-labs", resource.Tags[0].Value)
+	})
+
+	t.Run("external ID with characters that need escaping", func(t *testing.T) {
+		t.Parallel()
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assertEqual(t, "/tags/v0/resources/my-bucket%2Freports%2Fjune.csv/tags", r.URL.EscapedPath())
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(resourcePayload))
+		}))
+		defer server.Close()
+
+		_, err := testTagClient(server.URL).Resources().
+			AttachTags(context.Background(), "my-bucket/reports/june.csv", AttachTagsRequest{
+				Tags: []AttachTag{{Name: "environment", Value: "production"}},
+			})
+
+		assertNoError(t, err)
+	})
+
+	t.Run("invalid requests are rejected before the request", func(t *testing.T) {
+		t.Parallel()
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			t.Error("Expected no request to be sent")
+		}))
+		defer server.Close()
+
+		tests := []struct {
+			name       string
+			externalID string
+			req        AttachTagsRequest
+			field      string
+		}{
+			{
+				name:       "empty external ID",
+				externalID: "",
+				req:        AttachTagsRequest{Tags: []AttachTag{{Name: "environment", Value: "production"}}},
+				field:      "external_id",
+			},
+			{
+				name:       "no tags",
+				externalID: "d9f3a1b2",
+				req:        AttachTagsRequest{},
+				field:      "tags",
+			},
+			{
+				name:       "tag without a name",
+				externalID: "d9f3a1b2",
+				req:        AttachTagsRequest{Tags: []AttachTag{{Value: "production"}}},
+				field:      "tags[0].name",
+			},
+			{
+				name:       "tag without a value",
+				externalID: "d9f3a1b2",
+				req: AttachTagsRequest{Tags: []AttachTag{
+					{Name: "environment", Value: "production"},
+					{Name: "kubernetes-expenses"},
+				}},
+				field: "tags[1].value",
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				_, err := testTagClient(server.URL).Resources().
+					AttachTags(context.Background(), tt.externalID, tt.req)
+
+				assertValidationError(t, err, tt.field)
+			})
+		}
+	})
+
+	t.Run("api failure is reported", func(t *testing.T) {
+		t.Parallel()
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnprocessableEntity)
+			w.Write([]byte(`{"detail": "tag not found"}`))
+		}))
+		defer server.Close()
+
+		_, err := testTagClient(server.URL).Resources().
+			AttachTags(context.Background(), "d9f3a1b2", AttachTagsRequest{
+				Tags: []AttachTag{{Name: "environment", Value: "production"}},
+			})
+
+		assertError(t, err)
+	})
+}
+
+func TestResourceService_DetachTag(t *testing.T) {
+	t.Parallel()
+
+	t.Run("detaches a tag", func(t *testing.T) {
+		t.Parallel()
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assertEqual(t, "/tags/v0/resources/d9f3a1b2/tags/environment", r.URL.Path)
+			assertEqual(t, http.MethodDelete, r.Method)
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(resourcePayload))
+		}))
+		defer server.Close()
+
+		err := testTagClient(server.URL).Resources().
+			DetachTag(context.Background(), "d9f3a1b2", "environment")
+
+		assertNoError(t, err)
+	})
+
+	t.Run("names with characters that need escaping", func(t *testing.T) {
+		t.Parallel()
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assertEqual(t, "/tags/v0/resources/my-bucket%2Freports/tags/my%20tag%20%5Bprod%5D", r.URL.EscapedPath())
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(resourcePayload))
+		}))
+		defer server.Close()
+
+		err := testTagClient(server.URL).Resources().
+			DetachTag(context.Background(), "my-bucket/reports", "my tag [prod]")
+
+		assertNoError(t, err)
+	})
+
+	t.Run("invalid requests are rejected before the request", func(t *testing.T) {
+		t.Parallel()
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			t.Error("Expected no request to be sent")
+		}))
+		defer server.Close()
+
+		tests := []struct {
+			name       string
+			externalID string
+			tagName    string
+			field      string
+		}{
+			{name: "empty external ID", externalID: "", tagName: "environment", field: "external_id"},
+			{name: "empty tag name", externalID: "d9f3a1b2", tagName: "", field: "tag_name"},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				err := testTagClient(server.URL).Resources().
+					DetachTag(context.Background(), tt.externalID, tt.tagName)
+
+				assertValidationError(t, err, tt.field)
+			})
+		}
+	})
+
+	t.Run("api failure is reported", func(t *testing.T) {
+		t.Parallel()
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnprocessableEntity)
+			w.Write([]byte(`{"detail": "tag not attached"}`))
+		}))
+		defer server.Close()
+
+		err := testTagClient(server.URL).Resources().
+			DetachTag(context.Background(), "d9f3a1b2", "environment")
+
+		assertError(t, err)
+	})
+}

--- a/tag/tags.go
+++ b/tag/tags.go
@@ -2,7 +2,6 @@ package tag
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -75,44 +74,12 @@ type (
 	}
 
 	// UpdateTagRequest represents the parameters for updating a tag.
-	// Fields left nil are not sent, and the API keeps their current value.
-	// Fields set to an empty value clear the current one.
 	UpdateTagRequest struct {
 		Description *string    `json:"description,omitempty"`
 		Color       *string    `json:"color,omitempty"`
 		Kinds       *[]TagKind `json:"kinds,omitempty"`
 	}
-
-	// updateTagPayload is the wire form of UpdateTagRequest, where a field to be
-	// cleared is null and a field to be kept is absent.
-	updateTagPayload struct {
-		Description any        `json:"description,omitempty"`
-		Color       any        `json:"color,omitempty"`
-		Kinds       *[]TagKind `json:"kinds,omitempty"`
-	}
 )
-
-// MarshalJSON encodes only the fields the caller set, sending the ones set to an
-// empty value as null, which is how the API clears them.
-func (r UpdateTagRequest) MarshalJSON() ([]byte, error) {
-	return json.Marshal(updateTagPayload{
-		Description: clearableString(r.Description),
-		Color:       clearableString(r.Color),
-		Kinds:       r.Kinds,
-	})
-}
-
-// clearableString maps an optional string of an update request to its wire form:
-// nil is left out of the body, and an empty string becomes null.
-func clearableString(value *string) any {
-	if value == nil {
-		return nil
-	}
-	if *value == "" {
-		return (*string)(nil)
-	}
-	return *value
-}
 
 // TagService provides methods for managing tags.
 // All operations in this service are performed against the global endpoint,

--- a/tag/tags.go
+++ b/tag/tags.go
@@ -2,6 +2,7 @@ package tag
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -67,7 +68,7 @@ type (
 	// CreateTagRequest represents the parameters for creating a new tag
 	CreateTagRequest struct {
 		Name        string                  `json:"name"`
-		Description *string                 `json:"description"`
+		Description *string                 `json:"description,omitempty"`
 		Color       *string                 `json:"color,omitempty"`
 		Kinds       []TagKind               `json:"kinds,omitempty"`
 		Values      []CreateTagValueRequest `json:"values,omitempty"`
@@ -75,12 +76,43 @@ type (
 
 	// UpdateTagRequest represents the parameters for updating a tag.
 	// Fields left nil are not sent, and the API keeps their current value.
+	// Fields set to an empty value clear the current one.
 	UpdateTagRequest struct {
-		Description *string    `json:"description"`
+		Description *string    `json:"description,omitempty"`
 		Color       *string    `json:"color,omitempty"`
 		Kinds       *[]TagKind `json:"kinds,omitempty"`
 	}
+
+	// updateTagPayload is the wire form of UpdateTagRequest, where a field to be
+	// cleared is null and a field to be kept is absent.
+	updateTagPayload struct {
+		Description any        `json:"description,omitempty"`
+		Color       any        `json:"color,omitempty"`
+		Kinds       *[]TagKind `json:"kinds,omitempty"`
+	}
 )
+
+// MarshalJSON encodes only the fields the caller set, sending the ones set to an
+// empty value as null, which is how the API clears them.
+func (r UpdateTagRequest) MarshalJSON() ([]byte, error) {
+	return json.Marshal(updateTagPayload{
+		Description: clearableString(r.Description),
+		Color:       clearableString(r.Color),
+		Kinds:       r.Kinds,
+	})
+}
+
+// clearableString maps an optional string of an update request to its wire form:
+// nil is left out of the body, and an empty string becomes null.
+func clearableString(value *string) any {
+	if value == nil {
+		return nil
+	}
+	if *value == "" {
+		return (*string)(nil)
+	}
+	return *value
+}
 
 // TagService provides methods for managing tags.
 // All operations in this service are performed against the global endpoint,
@@ -203,7 +235,7 @@ func (s *tagService) Update(ctx context.Context, tagName string, req UpdateTagRe
 		return nil, &client.ValidationError{Field: "name", Message: "cannot be empty"}
 	}
 
-	if req.Color != nil {
+	if req.Color != nil && *req.Color != "" {
 		normalized, err := normalizeColor(*req.Color)
 		if err != nil {
 			return nil, err

--- a/tag/tags.go
+++ b/tag/tags.go
@@ -1,0 +1,245 @@
+package tag
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+
+	"github.com/MagaluCloud/mgc-sdk-go/client"
+	mgc_http "github.com/MagaluCloud/mgc-sdk-go/internal/http"
+	"github.com/MagaluCloud/mgc-sdk-go/internal/utils"
+)
+
+var colorRegexp = regexp.MustCompile(`^[0-9a-f]{6}$`)
+
+type (
+	// TagSummary identifies the tag that owns a value.
+	TagSummary struct {
+		Name        string  `json:"name"`
+		Description *string `json:"description"`
+	}
+
+	// TagValue represents a value of a tag.
+	TagValue struct {
+		Name        string                          `json:"name"`
+		Description *string                         `json:"description"`
+		CreatedAt   utils.LocalDateTimeWithoutZone  `json:"created_at"`
+		UpdatedAt   *utils.LocalDateTimeWithoutZone `json:"updated_at"`
+		// Tag is nil when the value comes embedded in a Tag.
+		Tag *TagSummary `json:"tag,omitempty"`
+	}
+
+	// Tag represents a tag and the values defined for it.
+	Tag struct {
+		Name        string                          `json:"name"`
+		Description *string                         `json:"description"`
+		Color       *string                         `json:"color"`
+		Kinds       []TagKind                       `json:"kinds"`
+		Values      []TagValue                      `json:"values"`
+		CreatedAt   utils.LocalDateTimeWithoutZone  `json:"created_at"`
+		UpdatedAt   *utils.LocalDateTimeWithoutZone `json:"updated_at"`
+	}
+
+	// ListTagsResponse represents the response of a tag listing
+	ListTagsResponse struct {
+		Results []Tag `json:"results"`
+	}
+
+	// ListTagsOptions defines the filters and pagination accepted when listing tags
+	ListTagsOptions struct {
+		Name   *string
+		Color  *string
+		Kinds  []TagKind
+		Limit  *int
+		Offset *int
+		Sort   *string
+	}
+
+	// CreateTagValueRequest represents the parameters for creating a value of a tag
+	CreateTagValueRequest struct {
+		Name        string  `json:"name"`
+		Description *string `json:"description,omitempty"`
+	}
+
+	// CreateTagRequest represents the parameters for creating a new tag
+	CreateTagRequest struct {
+		Name        string                  `json:"name"`
+		Description *string                 `json:"description"`
+		Color       *string                 `json:"color,omitempty"`
+		Kinds       []TagKind               `json:"kinds,omitempty"`
+		Values      []CreateTagValueRequest `json:"values,omitempty"`
+	}
+
+	// UpdateTagRequest represents the parameters for updating a tag.
+	// Fields left nil are not sent, and the API keeps their current value.
+	UpdateTagRequest struct {
+		Description *string    `json:"description"`
+		Color       *string    `json:"color,omitempty"`
+		Kinds       *[]TagKind `json:"kinds,omitempty"`
+	}
+)
+
+// TagService provides methods for managing tags.
+// All operations in this service are performed against the global endpoint,
+// as tags are not region-specific resources.
+type TagService interface {
+	// List retrieves the tags of the tenant. The API returns at most 100 items per
+	// call and defaults to 20, so use Limit and Offset to page through the results.
+	List(ctx context.Context, opts ListTagsOptions) ([]Tag, error)
+	// Get retrieves a tag by name, along with its values.
+	Get(ctx context.Context, tagName string) (*Tag, error)
+	// Create registers a new tag, optionally with its first values.
+	Create(ctx context.Context, req CreateTagRequest) (*Tag, error)
+	// Update changes the description, color or kinds of a tag.
+	Update(ctx context.Context, tagName string, req UpdateTagRequest) (*Tag, error)
+	// Delete removes a tag and every value defined for it.
+	Delete(ctx context.Context, tagName string) error
+}
+
+// tagService implements the TagService interface
+type tagService struct {
+	client *TagClient
+}
+
+// normalizeColor lowercases the color and validates it as a 6-digit hex RGB code
+// without the '#' prefix.
+func normalizeColor(color string) (string, error) {
+	lower := strings.ToLower(color)
+	if colorRegexp.MatchString(lower) {
+		return lower, nil
+	}
+	return "", &client.ValidationError{
+		Field:   "color",
+		Message: "must be a 6-character hexadecimal string representing RGB (e.g. f54927)",
+	}
+}
+
+func (s *tagService) List(ctx context.Context, opts ListTagsOptions) ([]Tag, error) {
+	query := makeListQuery(listOptions{Limit: opts.Limit, Offset: opts.Offset, Sort: opts.Sort})
+
+	if opts.Name != nil {
+		query.Set("name", *opts.Name)
+	}
+	if opts.Color != nil {
+		normalized, err := normalizeColor(*opts.Color)
+		if err != nil {
+			return nil, err
+		}
+		query.Set("color", normalized)
+	}
+	for _, kind := range opts.Kinds {
+		query.Add("kinds", string(kind))
+	}
+
+	result, err := mgc_http.ExecuteSimpleRequestWithRespBody[ListTagsResponse](
+		ctx,
+		s.client.newRequest,
+		s.client.GetConfig(),
+		http.MethodGet,
+		"/v0/tags",
+		nil,
+		query,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return result.Results, nil
+}
+
+func (s *tagService) Get(ctx context.Context, tagName string) (*Tag, error) {
+	if tagName == "" {
+		return nil, &client.ValidationError{Field: "name", Message: "cannot be empty"}
+	}
+
+	return mgc_http.ExecuteSimpleRequestWithRespBody[Tag](
+		ctx,
+		s.client.newRequest,
+		s.client.GetConfig(),
+		http.MethodGet,
+		tagPath(tagName),
+		nil,
+		nil,
+	)
+}
+
+func (s *tagService) Create(ctx context.Context, req CreateTagRequest) (*Tag, error) {
+	if req.Name == "" {
+		return nil, &client.ValidationError{Field: "name", Message: "cannot be empty"}
+	}
+
+	if req.Color != nil {
+		normalized, err := normalizeColor(*req.Color)
+		if err != nil {
+			return nil, err
+		}
+		req.Color = &normalized
+	}
+
+	for i, value := range req.Values {
+		if value.Name == "" {
+			return nil, &client.ValidationError{
+				Field:   fmt.Sprintf("values[%d].name", i),
+				Message: "cannot be empty",
+			}
+		}
+	}
+
+	return mgc_http.ExecuteSimpleRequestWithRespBody[Tag](
+		ctx,
+		s.client.newRequest,
+		s.client.GetConfig(),
+		http.MethodPost,
+		"/v0/tags",
+		req,
+		nil,
+	)
+}
+
+func (s *tagService) Update(ctx context.Context, tagName string, req UpdateTagRequest) (*Tag, error) {
+	if tagName == "" {
+		return nil, &client.ValidationError{Field: "name", Message: "cannot be empty"}
+	}
+
+	if req.Color != nil {
+		normalized, err := normalizeColor(*req.Color)
+		if err != nil {
+			return nil, err
+		}
+		req.Color = &normalized
+	}
+
+	return mgc_http.ExecuteSimpleRequestWithRespBody[Tag](
+		ctx,
+		s.client.newRequest,
+		s.client.GetConfig(),
+		http.MethodPatch,
+		tagPath(tagName),
+		req,
+		nil,
+	)
+}
+
+func (s *tagService) Delete(ctx context.Context, tagName string) error {
+	if tagName == "" {
+		return &client.ValidationError{Field: "name", Message: "cannot be empty"}
+	}
+
+	return mgc_http.ExecuteSimpleRequest(
+		ctx,
+		s.client.newRequest,
+		s.client.GetConfig(),
+		http.MethodDelete,
+		tagPath(tagName),
+		nil,
+		nil,
+	)
+}
+
+// tagPath builds the path of a tag. Tag names accept spaces and brackets, so they
+// have to be escaped.
+func tagPath(tagName string) string {
+	return "/v0/tags/" + url.PathEscape(tagName)
+}

--- a/tag/tags_test.go
+++ b/tag/tags_test.go
@@ -1,0 +1,595 @@
+package tag
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/MagaluCloud/mgc-sdk-go/helpers"
+	"github.com/MagaluCloud/mgc-sdk-go/internal/utils"
+)
+
+const tagPayload = `{
+	"name": "kubernetes-expenses",
+	"color": "f54927",
+	"kinds": ["finops"],
+	"description": "tag to monitor expenses with environments",
+	"created_at": "2025-06-20T18:36:18.919454",
+	"updated_at": "2025-06-21T18:36:18.919454",
+	"values": [
+		{
+			"name": "test-labs",
+			"description": "tag value to monitor expenses with test-labs",
+			"created_at": "2025-06-20T18:36:18.919454",
+			"updated_at": null
+		}
+	]
+}`
+
+func formatTime(t *testing.T, value utils.LocalDateTimeWithoutZone) string {
+	t.Helper()
+	return time.Time(value).Format(utils.LocalDateTimeWithoutZoneLayout)
+}
+
+func TestTagService_List(t *testing.T) {
+	t.Parallel()
+
+	t.Run("tags of the tenant with their values", func(t *testing.T) {
+		t.Parallel()
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assertEqual(t, "/tags/v0/tags", r.URL.Path)
+			assertEqual(t, http.MethodGet, r.Method)
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"results": [` + tagPayload + `]}`))
+		}))
+		defer server.Close()
+
+		tags, err := testTagClient(server.URL).Tags().List(context.Background(), ListTagsOptions{})
+
+		assertNoError(t, err)
+		assertEqual(t, 1, len(tags))
+		assertEqual(t, "kubernetes-expenses", tags[0].Name)
+		assertEqual(t, "f54927", *tags[0].Color)
+		assertEqual(t, "tag to monitor expenses with environments", *tags[0].Description)
+		assertEqual(t, 1, len(tags[0].Kinds))
+		assertEqual(t, TagKindFinops, tags[0].Kinds[0])
+		assertEqual(t, "2025-06-20T18:36:18.919454", formatTime(t, tags[0].CreatedAt))
+		assertEqual(t, "2025-06-21T18:36:18.919454", formatTime(t, *tags[0].UpdatedAt))
+		assertEqual(t, 1, len(tags[0].Values))
+		assertEqual(t, "test-labs", tags[0].Values[0].Name)
+		if tags[0].Values[0].UpdatedAt != nil {
+			t.Error("Expected a value never updated to have a nil UpdatedAt")
+		}
+		if tags[0].Values[0].Tag != nil {
+			t.Error("Expected a value embedded in a tag to carry no Tag reference")
+		}
+	})
+
+	t.Run("tag without description or color", func(t *testing.T) {
+		t.Parallel()
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"results": [{
+				"name": "no-metadata",
+				"color": null,
+				"description": null,
+				"kinds": [],
+				"values": [],
+				"created_at": "2025-06-20T18:36:18.919454",
+				"updated_at": null
+			}]}`))
+		}))
+		defer server.Close()
+
+		tags, err := testTagClient(server.URL).Tags().List(context.Background(), ListTagsOptions{})
+
+		assertNoError(t, err)
+		assertEqual(t, 1, len(tags))
+		if tags[0].Description != nil || tags[0].Color != nil {
+			t.Error("Expected null description and color to decode as nil, not empty string")
+		}
+	})
+
+	t.Run("kind the SDK does not know yet", func(t *testing.T) {
+		t.Parallel()
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"results": [{
+				"name": "future",
+				"kinds": ["secops"],
+				"values": [],
+				"description": null,
+				"created_at": "2025-06-20T18:36:18.919454",
+				"updated_at": null
+			}]}`))
+		}))
+		defer server.Close()
+
+		tags, err := testTagClient(server.URL).Tags().List(context.Background(), ListTagsOptions{})
+
+		assertNoError(t, err)
+		assertEqual(t, TagKind("secops"), tags[0].Kinds[0])
+	})
+
+	t.Run("empty result", func(t *testing.T) {
+		t.Parallel()
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"results": []}`))
+		}))
+		defer server.Close()
+
+		tags, err := testTagClient(server.URL).Tags().List(context.Background(), ListTagsOptions{})
+
+		assertNoError(t, err)
+		assertEqual(t, 0, len(tags))
+	})
+
+	t.Run("invalid response body", func(t *testing.T) {
+		t.Parallel()
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"results": `))
+		}))
+		defer server.Close()
+
+		_, err := testTagClient(server.URL).Tags().List(context.Background(), ListTagsOptions{})
+
+		assertError(t, err)
+	})
+
+	t.Run("api rejects the request", func(t *testing.T) {
+		t.Parallel()
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnprocessableEntity)
+			w.Write([]byte(`{"detail": [{"msg": "invalid color"}]}`))
+		}))
+		defer server.Close()
+
+		_, err := testTagClient(server.URL).Tags().List(context.Background(), ListTagsOptions{})
+
+		assertError(t, err)
+	})
+
+	t.Run("api failure is retried and then reported", func(t *testing.T) {
+		t.Parallel()
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte(`{"error": "server error"}`))
+		}))
+		defer server.Close()
+
+		_, err := testTagClient(server.URL).Tags().List(context.Background(), ListTagsOptions{})
+
+		assertError(t, err)
+	})
+}
+
+func TestTagService_List_Filters(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		opts      ListTagsOptions
+		wantQuery map[string][]string
+	}{
+		{
+			name:      "no filters sends no query",
+			opts:      ListTagsOptions{},
+			wantQuery: map[string][]string{},
+		},
+		{
+			name: "pagination",
+			opts: ListTagsOptions{
+				Limit:  helpers.IntPtr(10),
+				Offset: helpers.IntPtr(20),
+				Sort:   helpers.StrPtr("name:asc"),
+			},
+			wantQuery: map[string][]string{
+				"_limit":  {"10"},
+				"_offset": {"20"},
+				"_sort":   {"name:asc"},
+			},
+		},
+		{
+			name: "name and color",
+			opts: ListTagsOptions{
+				Name:  helpers.StrPtr("kubernetes-expenses"),
+				Color: helpers.StrPtr("F54927"),
+			},
+			wantQuery: map[string][]string{
+				"name":  {"kubernetes-expenses"},
+				"color": {"f54927"},
+			},
+		},
+		{
+			name:      "each kind is sent as its own parameter",
+			opts:      ListTagsOptions{Kinds: []TagKind{TagKindFinops, "secops"}},
+			wantQuery: map[string][]string{"kinds": {"finops", "secops"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				query := r.URL.Query()
+				assertEqual(t, len(tt.wantQuery), len(query))
+				for param, want := range tt.wantQuery {
+					got := query[param]
+					assertEqual(t, len(want), len(got), param)
+					for i := range want {
+						if i < len(got) {
+							assertEqual(t, want[i], got[i], param)
+						}
+					}
+				}
+				w.Header().Set("Content-Type", "application/json")
+				w.Write([]byte(`{"results": []}`))
+			}))
+			defer server.Close()
+
+			_, err := testTagClient(server.URL).Tags().List(context.Background(), tt.opts)
+
+			assertNoError(t, err)
+		})
+	}
+
+	t.Run("invalid color is rejected before the request", func(t *testing.T) {
+		t.Parallel()
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			t.Error("Expected no request for an invalid color")
+		}))
+		defer server.Close()
+
+		_, err := testTagClient(server.URL).Tags().
+			List(context.Background(), ListTagsOptions{Color: helpers.StrPtr("#f54927")})
+
+		assertValidationError(t, err, "color")
+	})
+}
+
+func TestTagService_Get(t *testing.T) {
+	t.Parallel()
+
+	t.Run("tag with its values", func(t *testing.T) {
+		t.Parallel()
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assertEqual(t, "/tags/v0/tags/kubernetes-expenses", r.URL.Path)
+			assertEqual(t, http.MethodGet, r.Method)
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(tagPayload))
+		}))
+		defer server.Close()
+
+		tag, err := testTagClient(server.URL).Tags().Get(context.Background(), "kubernetes-expenses")
+
+		assertNoError(t, err)
+		assertEqual(t, "kubernetes-expenses", tag.Name)
+		assertEqual(t, 1, len(tag.Values))
+	})
+
+	t.Run("name with characters that need escaping", func(t *testing.T) {
+		t.Parallel()
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assertEqual(t, "/tags/v0/tags/my tag [prod]", r.URL.Path)
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(tagPayload))
+		}))
+		defer server.Close()
+
+		_, err := testTagClient(server.URL).Tags().Get(context.Background(), "my tag [prod]")
+
+		assertNoError(t, err)
+	})
+
+	t.Run("empty name", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := testTagClient("https://tags.example.com").Tags().Get(context.Background(), "")
+
+		assertValidationError(t, err, "name")
+	})
+
+	t.Run("non-existent tag", func(t *testing.T) {
+		t.Parallel()
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+			w.Write([]byte(`{"detail": "tag not found"}`))
+		}))
+		defer server.Close()
+
+		_, err := testTagClient(server.URL).Tags().Get(context.Background(), "missing")
+
+		assertError(t, err)
+	})
+}
+
+func TestTagService_Create(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		req      CreateTagRequest
+		wantBody string
+	}{
+		{
+			name: "tag with every field",
+			req: CreateTagRequest{
+				Name:        "kubernetes-expenses",
+				Description: helpers.StrPtr("tag to monitor expenses with environments"),
+				Color:       helpers.StrPtr("F54927"),
+				Kinds:       []TagKind{TagKindFinops},
+				Values: []CreateTagValueRequest{
+					{Name: "test-labs", Description: helpers.StrPtr("labs")},
+				},
+			},
+			wantBody: `{
+				"name": "kubernetes-expenses",
+				"description": "tag to monitor expenses with environments",
+				"color": "f54927",
+				"kinds": ["finops"],
+				"values": [{"name": "test-labs", "description": "labs"}]
+			}`,
+		},
+		{
+			name:     "only the name is required",
+			req:      CreateTagRequest{Name: "minimal"},
+			wantBody: `{"name": "minimal"}`,
+		},
+		{
+			name: "value without description",
+			req: CreateTagRequest{
+				Name:   "with-values",
+				Values: []CreateTagValueRequest{{Name: "test-labs"}},
+			},
+			wantBody: `{"name": "with-values", "values": [{"name": "test-labs"}]}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assertEqual(t, "/tags/v0/tags", r.URL.Path)
+				assertEqual(t, http.MethodPost, r.Method)
+
+				body, err := io.ReadAll(r.Body)
+				assertNoError(t, err)
+				assertEqual(t, canonicalJSON(t, tt.wantBody), canonicalJSON(t, string(body)))
+
+				w.Header().Set("Content-Type", "application/json")
+				w.Write([]byte(tagPayload))
+			}))
+			defer server.Close()
+
+			tag, err := testTagClient(server.URL).Tags().Create(context.Background(), tt.req)
+
+			assertNoError(t, err)
+			assertEqual(t, "kubernetes-expenses", tag.Name)
+		})
+	}
+
+	validations := []struct {
+		name      string
+		req       CreateTagRequest
+		wantField string
+	}{
+		{
+			name:      "empty name",
+			req:       CreateTagRequest{},
+			wantField: "name",
+		},
+		{
+			name:      "invalid color",
+			req:       CreateTagRequest{Name: "tag", Color: helpers.StrPtr("red")},
+			wantField: "color",
+		},
+		{
+			name:      "value without name",
+			req:       CreateTagRequest{Name: "tag", Values: []CreateTagValueRequest{{Name: ""}}},
+			wantField: "values[0].name",
+		},
+	}
+
+	for _, tt := range validations {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				t.Error("Expected no request for invalid input")
+			}))
+			defer server.Close()
+
+			_, err := testTagClient(server.URL).Tags().Create(context.Background(), tt.req)
+
+			assertValidationError(t, err, tt.wantField)
+		})
+	}
+
+	t.Run("name already taken", func(t *testing.T) {
+		t.Parallel()
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusConflict)
+			w.Write([]byte(`{"detail": "tag already exists"}`))
+		}))
+		defer server.Close()
+
+		_, err := testTagClient(server.URL).Tags().
+			Create(context.Background(), CreateTagRequest{Name: "duplicated"})
+
+		assertError(t, err)
+	})
+}
+
+func TestTagService_Update(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		req      UpdateTagRequest
+		wantBody string
+	}{
+		{
+			name: "every field",
+			req: UpdateTagRequest{
+				Description: helpers.StrPtr("new description"),
+				Color:       helpers.StrPtr("FFFFFF"),
+				Kinds:       &[]TagKind{TagKindFinops},
+			},
+			wantBody: `{"description": "new description", "color": "ffffff", "kinds": ["finops"]}`,
+		},
+		{
+			name:     "only the fields that were set",
+			req:      UpdateTagRequest{Description: helpers.StrPtr("new description")},
+			wantBody: `{"description": "new description"}`,
+		},
+		{
+			name:     "empty kinds clears the list",
+			req:      UpdateTagRequest{Kinds: &[]TagKind{}},
+			wantBody: `{"kinds": []}`,
+		},
+		{
+			name:     "nothing to update sends an empty object",
+			req:      UpdateTagRequest{},
+			wantBody: `{}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assertEqual(t, "/tags/v0/tags/kubernetes-expenses", r.URL.Path)
+				assertEqual(t, http.MethodPatch, r.Method)
+
+				body, err := io.ReadAll(r.Body)
+				assertNoError(t, err)
+				assertEqual(t, canonicalJSON(t, tt.wantBody), canonicalJSON(t, string(body)))
+
+				w.Header().Set("Content-Type", "application/json")
+				w.Write([]byte(tagPayload))
+			}))
+			defer server.Close()
+
+			tag, err := testTagClient(server.URL).Tags().
+				Update(context.Background(), "kubernetes-expenses", tt.req)
+
+			assertNoError(t, err)
+			assertEqual(t, "kubernetes-expenses", tag.Name)
+		})
+	}
+
+	t.Run("empty name", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := testTagClient("https://tags.example.com").Tags().
+			Update(context.Background(), "", UpdateTagRequest{})
+
+		assertValidationError(t, err, "name")
+	})
+
+	t.Run("invalid color", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := testTagClient("https://tags.example.com").Tags().
+			Update(context.Background(), "tag", UpdateTagRequest{Color: helpers.StrPtr("f5492")})
+
+		assertValidationError(t, err, "color")
+	})
+}
+
+func TestTagService_Delete(t *testing.T) {
+	t.Parallel()
+
+	t.Run("tag is removed", func(t *testing.T) {
+		t.Parallel()
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assertEqual(t, "/tags/v0/tags/kubernetes-expenses", r.URL.Path)
+			assertEqual(t, http.MethodDelete, r.Method)
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(tagPayload))
+		}))
+		defer server.Close()
+
+		err := testTagClient(server.URL).Tags().Delete(context.Background(), "kubernetes-expenses")
+
+		assertNoError(t, err)
+	})
+
+	t.Run("empty name", func(t *testing.T) {
+		t.Parallel()
+
+		err := testTagClient("https://tags.example.com").Tags().Delete(context.Background(), "")
+
+		assertValidationError(t, err, "name")
+	})
+
+	t.Run("non-existent tag", func(t *testing.T) {
+		t.Parallel()
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+			w.Write([]byte(`{"detail": "tag not found"}`))
+		}))
+		defer server.Close()
+
+		err := testTagClient(server.URL).Tags().Delete(context.Background(), "missing")
+
+		assertError(t, err)
+	})
+}
+
+func TestNormalizeColor(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		color   string
+		want    string
+		wantErr bool
+	}{
+		{name: "lowercase hex", color: "f54927", want: "f54927"},
+		{name: "uppercase hex is normalized", color: "F54927", want: "f54927"},
+		{name: "mixed case is normalized", color: "F54aB7", want: "f54ab7"},
+		{name: "with hash prefix", color: "#f54927", wantErr: true},
+		{name: "too short", color: "f5492", wantErr: true},
+		{name: "too long", color: "f549277", wantErr: true},
+		{name: "not hexadecimal", color: "zzzzzz", wantErr: true},
+		{name: "empty", color: "", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := normalizeColor(tt.color)
+
+			if tt.wantErr {
+				assertValidationError(t, err, "color")
+				return
+			}
+			assertNoError(t, err)
+			assertEqual(t, tt.want, got)
+		})
+	}
+}

--- a/tag/tags_test.go
+++ b/tag/tags_test.go
@@ -462,6 +462,16 @@ func TestTagService_Update(t *testing.T) {
 			wantBody: `{"description": "new description"}`,
 		},
 		{
+			name:     "empty description clears it",
+			req:      UpdateTagRequest{Description: helpers.StrPtr("")},
+			wantBody: `{"description": null}`,
+		},
+		{
+			name:     "empty color clears it",
+			req:      UpdateTagRequest{Color: helpers.StrPtr("")},
+			wantBody: `{"color": null}`,
+		},
+		{
 			name:     "empty kinds clears the list",
 			req:      UpdateTagRequest{Kinds: &[]TagKind{}},
 			wantBody: `{"kinds": []}`,

--- a/tag/tags_test.go
+++ b/tag/tags_test.go
@@ -462,16 +462,6 @@ func TestTagService_Update(t *testing.T) {
 			wantBody: `{"description": "new description"}`,
 		},
 		{
-			name:     "empty description clears it",
-			req:      UpdateTagRequest{Description: helpers.StrPtr("")},
-			wantBody: `{"description": null}`,
-		},
-		{
-			name:     "empty color clears it",
-			req:      UpdateTagRequest{Color: helpers.StrPtr("")},
-			wantBody: `{"color": null}`,
-		},
-		{
 			name:     "empty kinds clears the list",
 			req:      UpdateTagRequest{Kinds: &[]TagKind{}},
 			wantBody: `{"kinds": []}`,

--- a/tag/values.go
+++ b/tag/values.go
@@ -1,0 +1,161 @@
+package tag
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+
+	"github.com/MagaluCloud/mgc-sdk-go/client"
+	mgc_http "github.com/MagaluCloud/mgc-sdk-go/internal/http"
+)
+
+type (
+	// ListTagValuesResponse represents the response of a tag value listing
+	ListTagValuesResponse struct {
+		Results []TagValue `json:"results"`
+	}
+
+	// ListTagValuesOptions defines the filters and pagination accepted when listing tag values
+	ListTagValuesOptions struct {
+		Name   *string
+		Limit  *int
+		Offset *int
+		Sort   *string
+	}
+
+	// UpdateTagValueRequest represents the parameters for updating a tag value.
+	// A nil Description clears the current one.
+	UpdateTagValueRequest struct {
+		Description *string `json:"description"`
+	}
+)
+
+// TagValueService provides methods for managing the values of a tag.
+type TagValueService interface {
+	// List retrieves the values of a tag. The API returns at most 100 items per
+	// call and defaults to 20, so use Limit and Offset to page through the results.
+	List(ctx context.Context, tagName string, opts ListTagValuesOptions) ([]TagValue, error)
+	// Get retrieves a value of a tag by name.
+	Get(ctx context.Context, tagName, valueName string) (*TagValue, error)
+	// Create adds a new value to an existing tag.
+	Create(ctx context.Context, tagName string, req CreateTagValueRequest) (*TagValue, error)
+	// Update changes the description of a value.
+	Update(ctx context.Context, tagName, valueName string, req UpdateTagValueRequest) (*TagValue, error)
+	// Delete removes a value from a tag.
+	Delete(ctx context.Context, tagName, valueName string) error
+}
+
+// tagValueService implements the TagValueService interface
+type tagValueService struct {
+	client *TagClient
+}
+
+func (s *tagValueService) List(ctx context.Context, tagName string, opts ListTagValuesOptions) ([]TagValue, error) {
+	if tagName == "" {
+		return nil, &client.ValidationError{Field: "tag_name", Message: "cannot be empty"}
+	}
+
+	query := makeListQuery(listOptions{Limit: opts.Limit, Offset: opts.Offset, Sort: opts.Sort})
+	if opts.Name != nil {
+		query.Set("name", *opts.Name)
+	}
+
+	result, err := mgc_http.ExecuteSimpleRequestWithRespBody[ListTagValuesResponse](
+		ctx,
+		s.client.newRequest,
+		s.client.GetConfig(),
+		http.MethodGet,
+		valuesPath(tagName),
+		nil,
+		query,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return result.Results, nil
+}
+
+func (s *tagValueService) Get(ctx context.Context, tagName, valueName string) (*TagValue, error) {
+	if err := validateValueNames(tagName, valueName); err != nil {
+		return nil, err
+	}
+
+	return mgc_http.ExecuteSimpleRequestWithRespBody[TagValue](
+		ctx,
+		s.client.newRequest,
+		s.client.GetConfig(),
+		http.MethodGet,
+		valuePath(tagName, valueName),
+		nil,
+		nil,
+	)
+}
+
+func (s *tagValueService) Create(ctx context.Context, tagName string, req CreateTagValueRequest) (*TagValue, error) {
+	if tagName == "" {
+		return nil, &client.ValidationError{Field: "tag_name", Message: "cannot be empty"}
+	}
+	if req.Name == "" {
+		return nil, &client.ValidationError{Field: "name", Message: "cannot be empty"}
+	}
+
+	return mgc_http.ExecuteSimpleRequestWithRespBody[TagValue](
+		ctx,
+		s.client.newRequest,
+		s.client.GetConfig(),
+		http.MethodPost,
+		valuesPath(tagName),
+		req,
+		nil,
+	)
+}
+
+func (s *tagValueService) Update(ctx context.Context, tagName, valueName string, req UpdateTagValueRequest) (*TagValue, error) {
+	if err := validateValueNames(tagName, valueName); err != nil {
+		return nil, err
+	}
+
+	return mgc_http.ExecuteSimpleRequestWithRespBody[TagValue](
+		ctx,
+		s.client.newRequest,
+		s.client.GetConfig(),
+		http.MethodPatch,
+		valuePath(tagName, valueName),
+		req,
+		nil,
+	)
+}
+
+func (s *tagValueService) Delete(ctx context.Context, tagName, valueName string) error {
+	if err := validateValueNames(tagName, valueName); err != nil {
+		return err
+	}
+
+	return mgc_http.ExecuteSimpleRequest(
+		ctx,
+		s.client.newRequest,
+		s.client.GetConfig(),
+		http.MethodDelete,
+		valuePath(tagName, valueName),
+		nil,
+		nil,
+	)
+}
+
+func validateValueNames(tagName, valueName string) error {
+	if tagName == "" {
+		return &client.ValidationError{Field: "tag_name", Message: "cannot be empty"}
+	}
+	if valueName == "" {
+		return &client.ValidationError{Field: "value_name", Message: "cannot be empty"}
+	}
+	return nil
+}
+
+func valuesPath(tagName string) string {
+	return tagPath(tagName) + "/values"
+}
+
+func valuePath(tagName, valueName string) string {
+	return valuesPath(tagName) + "/" + url.PathEscape(valueName)
+}

--- a/tag/values_test.go
+++ b/tag/values_test.go
@@ -1,0 +1,383 @@
+package tag
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/MagaluCloud/mgc-sdk-go/helpers"
+)
+
+const tagValuePayload = `{
+	"name": "test-labs",
+	"description": "tag value to monitor expenses with test-labs",
+	"created_at": "2025-06-20T18:36:18.919454",
+	"updated_at": "2025-06-21T18:36:18.919454",
+	"tag": {
+		"name": "kubernetes-expenses",
+		"description": "tag to monitor expenses with environments"
+	}
+}`
+
+func TestTagValueService_List(t *testing.T) {
+	t.Parallel()
+
+	t.Run("values of a tag", func(t *testing.T) {
+		t.Parallel()
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assertEqual(t, "/tags/v0/tags/kubernetes-expenses/values", r.URL.Path)
+			assertEqual(t, http.MethodGet, r.Method)
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"results": [` + tagValuePayload + `]}`))
+		}))
+		defer server.Close()
+
+		values, err := testTagClient(server.URL).Values().
+			List(context.Background(), "kubernetes-expenses", ListTagValuesOptions{})
+
+		assertNoError(t, err)
+		assertEqual(t, 1, len(values))
+		assertEqual(t, "test-labs", values[0].Name)
+		assertEqual(t, "tag value to monitor expenses with test-labs", *values[0].Description)
+		assertEqual(t, "2025-06-20T18:36:18.919454", formatTime(t, values[0].CreatedAt))
+		assertEqual(t, "kubernetes-expenses", values[0].Tag.Name)
+	})
+
+	t.Run("filters and pagination", func(t *testing.T) {
+		t.Parallel()
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			query := r.URL.Query()
+			assertEqual(t, 4, len(query))
+			assertEqual(t, "test-labs", query.Get("name"))
+			assertEqual(t, "5", query.Get("_limit"))
+			assertEqual(t, "10", query.Get("_offset"))
+			assertEqual(t, "name:asc", query.Get("_sort"))
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"results": []}`))
+		}))
+		defer server.Close()
+
+		_, err := testTagClient(server.URL).Values().
+			List(context.Background(), "kubernetes-expenses", ListTagValuesOptions{
+				Name:   helpers.StrPtr("test-labs"),
+				Limit:  helpers.IntPtr(5),
+				Offset: helpers.IntPtr(10),
+				Sort:   helpers.StrPtr("name:asc"),
+			})
+
+		assertNoError(t, err)
+	})
+
+	t.Run("empty tag name", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := testTagClient("https://tags.example.com").Values().
+			List(context.Background(), "", ListTagValuesOptions{})
+
+		assertValidationError(t, err, "tag_name")
+	})
+
+	t.Run("invalid response body", func(t *testing.T) {
+		t.Parallel()
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`not json`))
+		}))
+		defer server.Close()
+
+		_, err := testTagClient(server.URL).Values().
+			List(context.Background(), "kubernetes-expenses", ListTagValuesOptions{})
+
+		assertError(t, err)
+	})
+
+	t.Run("api failure is retried and then reported", func(t *testing.T) {
+		t.Parallel()
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte(`{"error": "server error"}`))
+		}))
+		defer server.Close()
+
+		_, err := testTagClient(server.URL).Values().
+			List(context.Background(), "kubernetes-expenses", ListTagValuesOptions{})
+
+		assertError(t, err)
+	})
+}
+
+func TestTagValueService_Get(t *testing.T) {
+	t.Parallel()
+
+	t.Run("value with the tag that owns it", func(t *testing.T) {
+		t.Parallel()
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assertEqual(t, "/tags/v0/tags/kubernetes-expenses/values/test-labs", r.URL.Path)
+			assertEqual(t, http.MethodGet, r.Method)
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(tagValuePayload))
+		}))
+		defer server.Close()
+
+		value, err := testTagClient(server.URL).Values().
+			Get(context.Background(), "kubernetes-expenses", "test-labs")
+
+		assertNoError(t, err)
+		assertEqual(t, "test-labs", value.Name)
+		assertEqual(t, "kubernetes-expenses", value.Tag.Name)
+		assertEqual(t, "tag to monitor expenses with environments", *value.Tag.Description)
+	})
+
+	t.Run("names with characters that need escaping", func(t *testing.T) {
+		t.Parallel()
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assertEqual(t, "/tags/v0/tags/my tag/values/prod (main)", r.URL.Path)
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(tagValuePayload))
+		}))
+		defer server.Close()
+
+		_, err := testTagClient(server.URL).Values().
+			Get(context.Background(), "my tag", "prod (main)")
+
+		assertNoError(t, err)
+	})
+
+	t.Run("empty tag name", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := testTagClient("https://tags.example.com").Values().
+			Get(context.Background(), "", "test-labs")
+
+		assertValidationError(t, err, "tag_name")
+	})
+
+	t.Run("empty value name", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := testTagClient("https://tags.example.com").Values().
+			Get(context.Background(), "kubernetes-expenses", "")
+
+		assertValidationError(t, err, "value_name")
+	})
+
+	t.Run("non-existent value", func(t *testing.T) {
+		t.Parallel()
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+			w.Write([]byte(`{"detail": "value not found"}`))
+		}))
+		defer server.Close()
+
+		_, err := testTagClient(server.URL).Values().
+			Get(context.Background(), "kubernetes-expenses", "missing")
+
+		assertError(t, err)
+	})
+}
+
+func TestTagValueService_Create(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		req      CreateTagValueRequest
+		wantBody string
+	}{
+		{
+			name:     "value with description",
+			req:      CreateTagValueRequest{Name: "test-labs", Description: helpers.StrPtr("labs")},
+			wantBody: `{"name": "test-labs", "description": "labs"}`,
+		},
+		{
+			name:     "description is optional",
+			req:      CreateTagValueRequest{Name: "test-labs"},
+			wantBody: `{"name": "test-labs"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assertEqual(t, "/tags/v0/tags/kubernetes-expenses/values", r.URL.Path)
+				assertEqual(t, http.MethodPost, r.Method)
+
+				body, err := io.ReadAll(r.Body)
+				assertNoError(t, err)
+				assertEqual(t, canonicalJSON(t, tt.wantBody), canonicalJSON(t, string(body)))
+
+				w.Header().Set("Content-Type", "application/json")
+				w.Write([]byte(tagValuePayload))
+			}))
+			defer server.Close()
+
+			value, err := testTagClient(server.URL).Values().
+				Create(context.Background(), "kubernetes-expenses", tt.req)
+
+			assertNoError(t, err)
+			assertEqual(t, "test-labs", value.Name)
+		})
+	}
+
+	t.Run("empty tag name", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := testTagClient("https://tags.example.com").Values().
+			Create(context.Background(), "", CreateTagValueRequest{Name: "test-labs"})
+
+		assertValidationError(t, err, "tag_name")
+	})
+
+	t.Run("empty value name", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := testTagClient("https://tags.example.com").Values().
+			Create(context.Background(), "kubernetes-expenses", CreateTagValueRequest{})
+
+		assertValidationError(t, err, "name")
+	})
+
+	t.Run("name already taken within the tag", func(t *testing.T) {
+		t.Parallel()
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusConflict)
+			w.Write([]byte(`{"detail": "value already exists"}`))
+		}))
+		defer server.Close()
+
+		_, err := testTagClient(server.URL).Values().
+			Create(context.Background(), "kubernetes-expenses", CreateTagValueRequest{Name: "test-labs"})
+
+		assertError(t, err)
+	})
+}
+
+func TestTagValueService_Update(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		req      UpdateTagValueRequest
+		wantBody string
+	}{
+		{
+			name:     "new description",
+			req:      UpdateTagValueRequest{Description: helpers.StrPtr("new description")},
+			wantBody: `{"description": "new description"}`,
+		},
+		{
+			name:     "nil description clears it",
+			req:      UpdateTagValueRequest{},
+			wantBody: `{"description": null}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assertEqual(t, "/tags/v0/tags/kubernetes-expenses/values/test-labs", r.URL.Path)
+				assertEqual(t, http.MethodPatch, r.Method)
+
+				body, err := io.ReadAll(r.Body)
+				assertNoError(t, err)
+				assertEqual(t, canonicalJSON(t, tt.wantBody), canonicalJSON(t, string(body)))
+
+				w.Header().Set("Content-Type", "application/json")
+				w.Write([]byte(tagValuePayload))
+			}))
+			defer server.Close()
+
+			value, err := testTagClient(server.URL).Values().
+				Update(context.Background(), "kubernetes-expenses", "test-labs", tt.req)
+
+			assertNoError(t, err)
+			assertEqual(t, "test-labs", value.Name)
+		})
+	}
+
+	t.Run("empty tag name", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := testTagClient("https://tags.example.com").Values().
+			Update(context.Background(), "", "test-labs", UpdateTagValueRequest{})
+
+		assertValidationError(t, err, "tag_name")
+	})
+
+	t.Run("empty value name", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := testTagClient("https://tags.example.com").Values().
+			Update(context.Background(), "kubernetes-expenses", "", UpdateTagValueRequest{})
+
+		assertValidationError(t, err, "value_name")
+	})
+}
+
+func TestTagValueService_Delete(t *testing.T) {
+	t.Parallel()
+
+	t.Run("value is removed", func(t *testing.T) {
+		t.Parallel()
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assertEqual(t, "/tags/v0/tags/kubernetes-expenses/values/test-labs", r.URL.Path)
+			assertEqual(t, http.MethodDelete, r.Method)
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(tagValuePayload))
+		}))
+		defer server.Close()
+
+		err := testTagClient(server.URL).Values().
+			Delete(context.Background(), "kubernetes-expenses", "test-labs")
+
+		assertNoError(t, err)
+	})
+
+	t.Run("empty tag name", func(t *testing.T) {
+		t.Parallel()
+
+		err := testTagClient("https://tags.example.com").Values().
+			Delete(context.Background(), "", "test-labs")
+
+		assertValidationError(t, err, "tag_name")
+	})
+
+	t.Run("empty value name", func(t *testing.T) {
+		t.Parallel()
+
+		err := testTagClient("https://tags.example.com").Values().
+			Delete(context.Background(), "kubernetes-expenses", "")
+
+		assertValidationError(t, err, "value_name")
+	})
+
+	t.Run("non-existent value", func(t *testing.T) {
+		t.Parallel()
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+			w.Write([]byte(`{"detail": "value not found"}`))
+		}))
+		defer server.Close()
+
+		err := testTagClient(server.URL).Values().
+			Delete(context.Background(), "kubernetes-expenses", "missing")
+
+		assertError(t, err)
+	})
+}


### PR DESCRIPTION
## What does this PR do?
Adiciona o pacote `tag`, cobrindo as quatro APIs de tags: as tags, seus
valores, os tipos de recurso que suportam tagueamento e as tags anexadas
aos recursos de outros produtos.

- Tags são um serviço global: o client monta as requisições sobre uma
  cópia da config apontando para o endpoint global, então o core client
  compartilhado com os outros serviços mantém a região dele.
  `WithGlobalBasePath` permite sobrescrever.
  
  
## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
